### PR TITLE
Handle optional config parameters in authorization request_object generation

### DIFF
--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -176,12 +176,28 @@ attempt_request_object(QueryParams, #oidcc_client_context{
     provider_configuration = #oidcc_provider_configuration{
         issuer = Issuer,
         request_parameter_supported = true,
-        request_object_signing_alg_values_supported = SigningAlgSupported,
-        request_object_encryption_alg_values_supported = EncryptionAlgSupported,
-        request_object_encryption_enc_values_supported = EncryptionEncSupported
+        request_object_signing_alg_values_supported = SigningAlgSupported0,
+        request_object_encryption_alg_values_supported = EncryptionAlgSupported0,
+        request_object_encryption_enc_values_supported = EncryptionEncSupported0
     },
     jwks = Jwks
 }) ->
+    SigningAlgSupported =
+        case SigningAlgSupported0 of
+            undefined -> [];
+            SigningAlgs -> SigningAlgs
+        end,
+    EncryptionAlgSupported =
+        case EncryptionAlgSupported0 of
+            undefined -> [];
+            EncryptionAlgs -> EncryptionAlgs
+        end,
+    EncryptionEncSupported =
+        case EncryptionEncSupported0 of
+            undefined -> [];
+            EncryptionEncs -> EncryptionEncs
+        end,
+
     JwksWithClientJwks =
         case ClientJwks of
             none -> Jwks;

--- a/test/oidcc_authorization_SUITE.erl
+++ b/test/oidcc_authorization_SUITE.erl
@@ -1,0 +1,48 @@
+-module(oidcc_authorization_SUITE).
+
+-export([all/0]).
+-export([create_redirect_url_inl_gov/1]).
+
+-include_lib("stdlib/include/assert.hrl").
+
+all() ->
+    [create_redirect_url_inl_gov].
+
+create_redirect_url_inl_gov(_Config) ->
+    {ok, InlGovPid} =
+        oidcc_provider_configuration_worker:start_link(#{
+            issuer => <<"https://identity-preview.inl.gov">>
+        }),
+
+    {ok, ClientContext} = oidcc_client_context:from_configuration_worker(
+        InlGovPid, <<"client_id">>, <<"client_secret">>
+    ),
+
+    {ok, Url} = oidcc_authorization:create_redirect_url(ClientContext, #{
+        redirect_uri => <<"https://my.server/return">>
+    }),
+
+    ?assertMatch(
+        <<"https://identity-preview.inl.gov/oauth2/v1/authorize?request=", _/binary>>,
+        iolist_to_binary(Url)
+    ),
+
+    #{query := QueryString} = uri_string:parse(Url),
+    QueryParams0 = uri_string:dissect_query(QueryString),
+    QueryParams1 = lists:map(
+        fun({Key, Value}) -> {list_to_binary(Key), list_to_binary(Value)} end, QueryParams0
+    ),
+    QueryParams = maps:from_list(QueryParams1),
+
+    ?assertMatch(
+        #{
+            <<"client_id">> := <<"client_id">>,
+            <<"redirect_uri">> := <<"https://my.server/return">>,
+            <<"response_type">> := <<"code">>,
+            <<"scope">> := <<"openid">>,
+            <<"request">> := _
+        },
+        QueryParams
+    ),
+
+    ok.

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -305,3 +305,54 @@ create_redirect_url_with_invalid_request_object_test() ->
     ),
 
     ok.
+
+create_redirect_url_with_missing_config_request_object_test() ->
+    PrivDir = code:priv_dir(oidcc),
+
+    %% Enable none algorithm for test
+    jose:unsecured_signing(true),
+
+    {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+    {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
+        jose:decode(ValidConfigString)
+    ),
+
+    Configuration = Configuration0#oidcc_provider_configuration{
+        request_parameter_supported = true
+    },
+
+    ClientId = <<"client_id">>,
+    ClientSecret = <<"at_least_32_character_client_secret">>,
+
+    Jwks0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
+    Jwks = Jwks0#jose_jwk{fields = #{<<"use">> => <<"sig">>}},
+
+    RedirectUri = <<"https://my.server/return">>,
+
+    ClientContext =
+        oidcc_client_context:from_manual(Configuration, Jwks, ClientId, ClientSecret),
+
+    {ok, Url} = oidcc_authorization:create_redirect_url(ClientContext, #{
+        redirect_uri => RedirectUri
+    }),
+
+    ?assertMatch(<<"https://my.provider/auth?scope=", _/binary>>, iolist_to_binary(Url)),
+
+    #{query := QueryString} = uri_string:parse(Url),
+    QueryParams0 = uri_string:dissect_query(QueryString),
+    QueryParams1 = lists:map(
+        fun({Key, Value}) -> {list_to_binary(Key), list_to_binary(Value)} end, QueryParams0
+    ),
+    QueryParams = maps:from_list(QueryParams1),
+
+    ?assertEqual(
+        #{
+            <<"client_id">> => <<"client_id">>,
+            <<"redirect_uri">> => <<"https://my.server/return">>,
+            <<"response_type">> => <<"code">>,
+            <<"scope">> => <<"openid">>
+        },
+        QueryParams
+    ),
+
+    ok.


### PR DESCRIPTION
Fixes #280 
