### PR TITLE
feat: support Elixir 1.14.4+

### DIFF
--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -170,6 +170,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - elixir: "1.14.5"
+            unstable: false
           - elixir: "1.15.0"
             unstable: false
           - elixir: "1.15.7"

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Oidcc.Mixfile do
     [
       app: :oidcc,
       version: to_string(@props[:vsn]),
-      elixir: "~> 1.15",
+      elixir: ">= 1.14.4 and < 2.0.0",
       erlc_options: erlc_options(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
1.14.4 was the first Elixir release to support OTP 26: https://github.com/elixir-lang/elixir/releases/tag/v1.14.4

There doesn't appear to be anything about Oidcc which requires features in 1.15, so Oidcc can express support for slightly earlier versions.

<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->
