### PR TITLE
fix: don't crash if `none` is a supported request signing alg

### DIFF
--- a/src/oidcc_jwt_util.erl
+++ b/src/oidcc_jwt_util.erl
@@ -185,6 +185,14 @@ sign(Jwt, Jwk, [Algorithm | RestAlgorithms]) ->
                 %% Some Keys crash if a public key is provided
                 error:function_clause -> error
             end;
+        (#jose_jwk{} = Key) when Algorithm == <<"none">> ->
+            try
+                {_Jws, Token} = jose_jws:compact(jose_jwt:sign(Key, Jws, Jwt)),
+                {ok, Token}
+            catch
+                error:not_supported -> error;
+                error:{not_supported, _Alg} -> error
+            end;
         (_Key) ->
             error
     end,


### PR DESCRIPTION
Instead, catch the error and allow the upstream to fall back to a different approach. For the `oidcc_authorization` module, that means normal query parameters rather than a signed request object.

In particular, I ran into this when calling `create_redirect_url` with a client ID and client secret (not `:unauthenticated`) when `none` is a supported request signing alg.

This might be eliminating support for `none` signed request JWTs entirely, but it wasn't clear whether that's required for clients.

<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

<!--
- Please target the oldest branch of oidcc that is still supported and
  affected by this bug.
-->
