### PR TITLE
Specify minimum OTP26 version requirement in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The refactoring for `v3` and the certification is funded as an
 
 ## Setup
 
+**Please note that the minimum supported Erlang OTP version is OTP26.**
+
 ### Erlang
 
 **directly**


### PR DESCRIPTION
Fixes: #296 

## Generated ExDoc
<img width="856" alt="Screenshot 2023-12-05 at 18 58 39" src="https://github.com/erlef/oidcc/assets/13085275/50e21bce-0d5d-4e80-b921-e960976bf83b">

## GitHub markdown preview
<img width="926" alt="Screenshot 2023-12-05 at 19 00 50" src="https://github.com/erlef/oidcc/assets/13085275/1e054ce3-c4d6-4948-9939-41f18e30e52d">

Closes https://github.com/erlef/oidcc/issues/296