### PR TITLE
two bugs with `request` param

### DIFF
--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -80,7 +80,8 @@ create_redirect_url(#oidcc_client_context{} = ClientContext, Opts) ->
 
     case lists:member(<<"authorization_code">>, GrantTypesSupported) of
         true ->
-            QueryParams = redirect_params(ClientContext, Opts),
+            QueryParams0 = redirect_params(ClientContext, Opts),
+            QueryParams = QueryParams0 ++ maps:get(url_extension, Opts, []),
             QueryString = uri_string:compose_query(QueryParams),
 
             {ok, [AuthEndpoint, <<"?">>, QueryString]};
@@ -97,7 +98,6 @@ redirect_params(#oidcc_client_context{client_id = ClientId} = ClientContext, Opt
             {<<"response_type">>, maps:get(response_type, Opts, <<"code">>)},
             {<<"client_id">>, ClientId},
             {<<"redirect_uri">>, maps:get(redirect_uri, Opts)}
-            | maps:get(url_extension, Opts, [])
         ],
     QueryParams1 = maybe_append(<<"state">>, maps:get(state, Opts, undefined), QueryParams),
     QueryParams2 = maybe_append(<<"nonce">>, maps:get(nonce, Opts, undefined), QueryParams1),

--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -273,14 +273,14 @@ essential_params(QueryParams) ->
 
 -spec deprioritize_none_alg(Algorithms :: [binary()]) -> [binary()].
 deprioritize_none_alg(Algorithms) ->
-    lists:usort(
+    {WithNone, WithoutNone} = lists:partition(
         fun
-            (<<"none">>, _B) -> false;
-            (_A, <<"none">>) -> true;
-            (_A, _B) -> true
+            (<<"none">>) -> true;
+            (_) -> false
         end,
         Algorithms
-    ).
+    ),
+    WithoutNone ++ WithNone.
 
 -spec random_string(Bytes :: pos_integer()) -> binary().
 random_string(Bytes) ->

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -198,7 +198,8 @@ create_redirect_url_with_request_object_test() ->
         oidcc_client_context:from_manual(Configuration, Jwks, ClientId, ClientSecret),
 
     {ok, Url} = oidcc_authorization:create_redirect_url(ClientContext, #{
-        redirect_uri => RedirectUri
+        redirect_uri => RedirectUri,
+        url_extension => [{<<"should_be_in">>, <<"query_string">>}]
     }),
 
     ?assertMatch(<<"https://my.provider/auth?request=", _/binary>>, iolist_to_binary(Url)),
@@ -216,6 +217,7 @@ create_redirect_url_with_request_object_test() ->
             <<"redirect_uri">> := <<"https://my.server/return">>,
             <<"response_type">> := <<"code">>,
             <<"scope">> := <<"openid">>,
+            <<"should_be_in">> := <<"query_string">>,
             <<"request">> := _
         },
         QueryParams

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -261,9 +261,9 @@ create_redirect_url_with_request_object_and_max_clock_skew_test() ->
         request_parameter_supported = true,
         request_object_signing_alg_values_supported = [
             <<"none">>,
+            <<"PS256">>,
             <<"HS256">>,
             <<"RS256">>,
-            <<"PS256">>,
             <<"ES256">>,
             <<"EdDSA">>
         ],


### PR DESCRIPTION
More notes in the individual commits, but the tl;dr;
- correct the sorting of signing/encryption algorithms
- put `url_extension` parameters in the URL even when using a `request` param

<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

<!--
- Please target the oldest branch of oidcc that is still supported and
  affected by this bug.
-->
