### PR TITLE
introspection improvements

### DIFF
--- a/include/oidcc_token_introspection.hrl
+++ b/include/oidcc_token_introspection.hrl
@@ -1,11 +1,20 @@
 -ifndef(OIDCC_TOKEN_INTROSPECTION_HRL).
 
+%% @see https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
 -record(oidcc_token_introspection, {
     active :: boolean(),
     client_id :: binary(),
-    exp :: pos_integer(),
+    exp :: pos_integer() | undefined,
     scope :: oidcc_scope:scopes(),
-    username :: binary()
+    username :: binary() | undefined,
+    token_type :: binary() | undefined,
+    iat :: pos_integer() | undefined,
+    nbf :: pos_integer() | undefined,
+    sub :: binary() | undefined,
+    aud :: binary() | undefined,
+    iss :: binary() | undefined,
+    jti :: binary() | undefined,
+    extra :: #{binary() := term()}
 }).
 
 -define(OIDCC_TOKEN_INTROSPECTION_HRL, 1).

--- a/lib/oidcc/token_introspection.ex
+++ b/lib/oidcc/token_introspection.ex
@@ -41,13 +41,25 @@ defmodule Oidcc.TokenIntrospection do
   alias Oidcc.ClientContext
   alias Oidcc.Token
 
+  @typedoc """
+  For details on the fields see:
+  * https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
+  """
   @typedoc since: "3.0.0"
   @type t() :: %__MODULE__{
           active: boolean(),
           client_id: binary(),
-          exp: pos_integer(),
+          exp: pos_integer() | :undefined,
           scope: :oidcc_scope.scopes(),
-          username: binary()
+          username: binary() | :undefined,
+          token_type: binary() | :undefined,
+          iat: pos_integer() | :undefined,
+          nbf: pos_integer() | :undefined,
+          sub: binary() | :undefined,
+          aud: binary() | :undefined,
+          iss: binary() | :undefined,
+          jti: binary() | :undefined,
+          extra: %{binary() => term()}
         }
 
   @doc """

--- a/src/oidcc_auth_util.erl
+++ b/src/oidcc_auth_util.erl
@@ -121,18 +121,6 @@ add_authentication(
     QsBodyList,
     Header,
     client_secret_jwt,
-    AlgValuesSupported,
-    ClientContext
-) when AlgValuesSupported == []; AlgValuesSupported == undefined ->
-    %% https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
-    %% Servers SHOULD support RS256.
-    add_authentication(
-        QsBodyList, Header, client_secret_jwt, [<<"RS256">>, <<"HS256">>], ClientContext
-    );
-add_authentication(
-    QsBodyList,
-    Header,
-    client_secret_jwt,
     AllowAlgorithms,
     ClientContext
 ) ->

--- a/src/oidcc_auth_util.erl
+++ b/src/oidcc_auth_util.erl
@@ -1,0 +1,254 @@
+%%%-------------------------------------------------------------------
+%% @doc Authentication Utilities
+%% @end
+%%%-------------------------------------------------------------------
+-module(oidcc_auth_util).
+
+-feature(maybe_expr, enable).
+
+-include("oidcc_client_context.hrl").
+-include("oidcc_provider_configuration.hrl").
+
+-include_lib("jose/include/jose_jwk.hrl").
+
+-export_type([auth_method/0, error/0]).
+
+-type auth_method() ::
+    none | client_secret_basic | client_secret_post | client_secret_jwt | private_key_jwt.
+
+-type error() :: no_supported_auth_method.
+
+-export([add_client_authentication/6]).
+
+%% @private
+-spec add_client_authentication(
+    QueryList, Header, SupportedAuthMethods, AllowAlgorithms, Opts, ClientContext
+) ->
+    {ok, {oidcc_http_util:query_params(), [oidcc_http_util:http_header()]}}
+    | {error, error()}
+when
+    QueryList :: oidcc_http_util:query_params(),
+    Header :: [oidcc_http_util:http_header()],
+    SupportedAuthMethods :: [binary()] | undefined,
+    AllowAlgorithms :: [binary()] | undefined,
+    Opts :: map(),
+    ClientContext :: oidcc_client_context:t().
+add_client_authentication(_QueryList, _Header, undefined, _AllowAlgs, _Opts, _ClientContext) ->
+    {error, no_supported_auth_method};
+add_client_authentication(
+    QueryList0, Header0, SupportedAuthMethods, AllowAlgorithms, Opts, ClientContext
+) ->
+    PreferredAuthMethods = maps:get(preferred_auth_methods, Opts, [
+        private_key_jwt,
+        client_secret_jwt,
+        client_secret_post,
+        client_secret_basic,
+        none
+    ]),
+    case select_preferred_auth(PreferredAuthMethods, SupportedAuthMethods) of
+        {ok, AuthMethod} ->
+            case
+                add_authentication(QueryList0, Header0, AuthMethod, AllowAlgorithms, ClientContext)
+            of
+                {ok, {QueryList, Header}} ->
+                    {ok, {QueryList, Header}};
+                {error, _} ->
+                    add_client_authentication(
+                        QueryList0,
+                        Header0,
+                        SupportedAuthMethods -- [atom_to_binary(AuthMethod)],
+                        AllowAlgorithms,
+                        Opts,
+                        ClientContext
+                    )
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec add_authentication(
+    QueryList,
+    Header,
+    AuthMethod,
+    AllowAlgorithms,
+    ClientContext
+) ->
+    {ok, {oidcc_http_util:query_params(), [oidcc_http_util:http_header()]}}
+    | {error, auth_method_not_possible}
+when
+    QueryList :: oidcc_http_util:query_params(),
+    Header :: [oidcc_http_util:http_header()],
+    AuthMethod :: auth_method(),
+    AllowAlgorithms :: [binary()] | undefined,
+    ClientContext :: oidcc_client_context:t().
+add_authentication(
+    QsBodyList,
+    Header,
+    none,
+    _AllowArgs,
+    #oidcc_client_context{client_id = ClientId}
+) ->
+    NewBodyList = [{<<"client_id">>, ClientId} | QsBodyList],
+    {ok, {NewBodyList, Header}};
+add_authentication(
+    _QsBodyList,
+    _Header,
+    _Method,
+    _AllowAlgs,
+    #oidcc_client_context{client_secret = unauthenticated}
+) ->
+    {error, auth_method_not_possible};
+add_authentication(
+    QsBodyList,
+    Header,
+    client_secret_basic,
+    _AllowAlgs,
+    #oidcc_client_context{client_id = ClientId, client_secret = ClientSecret}
+) ->
+    NewHeader = [oidcc_http_util:basic_auth_header(ClientId, ClientSecret) | Header],
+    {ok, {QsBodyList, NewHeader}};
+add_authentication(
+    QsBodyList,
+    Header,
+    client_secret_post,
+    _AllowAlgs,
+    #oidcc_client_context{client_id = ClientId, client_secret = ClientSecret}
+) ->
+    NewBodyList =
+        [{<<"client_id">>, ClientId}, {<<"client_secret">>, ClientSecret} | QsBodyList],
+    {ok, {NewBodyList, Header}};
+add_authentication(
+    QsBodyList,
+    Header,
+    client_secret_jwt,
+    AlgValuesSupported,
+    ClientContext
+) when AlgValuesSupported == []; AlgValuesSupported == undefined ->
+    %% https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+    %% Servers SHOULD support RS256.
+    add_authentication(
+        QsBodyList, Header, client_secret_jwt, [<<"RS256">>, <<"HS256">>], ClientContext
+    );
+add_authentication(
+    QsBodyList,
+    Header,
+    client_secret_jwt,
+    AllowAlgorithms,
+    ClientContext
+) ->
+    #oidcc_client_context{
+        client_secret = ClientSecret
+    } = ClientContext,
+
+    maybe
+        [_ | _] ?= AllowAlgorithms,
+        #jose_jwk{} =
+            OctJwk ?=
+                oidcc_jwt_util:client_secret_oct_keys(
+                    AllowAlgorithms,
+                    ClientSecret
+                ),
+        {ok, ClientAssertion} ?=
+            signed_client_assertion(
+                AllowAlgorithms,
+                ClientContext,
+                OctJwk
+            ),
+        {ok, add_jwt_bearer_assertion(ClientAssertion, QsBodyList, Header, ClientContext)}
+    else
+        _ ->
+            {error, auth_method_not_possible}
+    end;
+add_authentication(
+    QsBodyList,
+    Header,
+    private_key_jwt,
+    AllowAlgorithms,
+    ClientContext
+) ->
+    #oidcc_client_context{
+        client_jwks = ClientJwks
+    } = ClientContext,
+
+    maybe
+        [_ | _] ?= AllowAlgorithms,
+        #jose_jwk{} ?= ClientJwks,
+        {ok, ClientAssertion} ?=
+            signed_client_assertion(AllowAlgorithms, ClientContext, ClientJwks),
+        {ok, add_jwt_bearer_assertion(ClientAssertion, QsBodyList, Header, ClientContext)}
+    else
+        _ ->
+            {error, auth_method_not_possible}
+    end.
+
+-spec select_preferred_auth(PreferredAuthMethods, AuthMethodsSupported) ->
+    {ok, auth_method()} | {error, error()}
+when
+    PreferredAuthMethods :: [auth_method(), ...],
+    AuthMethodsSupported :: [binary()].
+select_preferred_auth(PreferredAuthMethods, AuthMethodsSupported) ->
+    PreferredAuthMethodSearchFun = fun(AuthMethod) ->
+        lists:member(atom_to_binary(AuthMethod), AuthMethodsSupported)
+    end,
+
+    case lists:search(PreferredAuthMethodSearchFun, PreferredAuthMethods) of
+        {value, AuthMethod} ->
+            {ok, AuthMethod};
+        false ->
+            {error, no_supported_auth_method}
+    end.
+
+-spec signed_client_assertion(AllowAlgorithms, ClientContext, Jwk) ->
+    {ok, binary()} | {error, term()}
+when
+    AllowAlgorithms :: [binary()],
+    Jwk :: jose_jwk:key(),
+    ClientContext :: oidcc_client_context:t().
+signed_client_assertion(AllowAlgorithms, ClientContext, Jwk) ->
+    Jwt = jose_jwt:from(token_request_claims(ClientContext)),
+
+    oidcc_jwt_util:sign(Jwt, Jwk, AllowAlgorithms).
+
+-spec token_request_claims(ClientContext) -> oidcc_jwt_util:claims() when
+    ClientContext :: oidcc_client_context:t().
+token_request_claims(#oidcc_client_context{
+    client_id = ClientId,
+    provider_configuration = #oidcc_provider_configuration{token_endpoint = TokenEndpoint}
+}) ->
+    MaxClockSkew =
+        case application:get_env(oidcc, max_clock_skew) of
+            undefined -> 0;
+            {ok, ClockSkew} -> ClockSkew
+        end,
+
+    #{
+        <<"iss">> => ClientId,
+        <<"sub">> => ClientId,
+        <<"aud">> => TokenEndpoint,
+        <<"jti">> => random_string(32),
+        <<"iat">> => os:system_time(seconds),
+        <<"exp">> => os:system_time(seconds) + 30,
+        <<"nbf">> => os:system_time(seconds) - MaxClockSkew
+    }.
+
+-spec add_jwt_bearer_assertion(ClientAssertion, Body, Header, ClientContext) -> {Body, Header} when
+    ClientAssertion :: binary(),
+    Body :: oidcc_http_util:query_params(),
+    Header :: [oidcc_http_util:http_header()],
+    ClientContext :: oidcc_client_context:t().
+add_jwt_bearer_assertion(ClientAssertion, Body, Header, ClientContext) ->
+    #oidcc_client_context{client_id = ClientId} = ClientContext,
+    {
+        [
+            {<<"client_assertion_type">>,
+                <<"urn:ietf:params:oauth:client-assertion-type:jwt-bearer">>},
+            {<<"client_assertion">>, ClientAssertion},
+            {<<"client_id">>, ClientId}
+            | Body
+        ],
+        Header
+    }.
+
+-spec random_string(Bytes :: pos_integer()) -> binary().
+random_string(Bytes) ->
+    base64:encode(crypto:strong_rand_bytes(Bytes), #{mode => urlsafe, padding => false}).

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -16,7 +16,7 @@
 
 -type query_params() :: [{unicode:chardata(), unicode:chardata() | true}].
 %% See {@link uri_string:compose_query/1}
--type http_header() :: {Field :: [byte()], Value :: iodata()}.
+-type http_header() :: {Field :: [byte()] | binary(), Value :: iodata()}.
 %% See {@link httpc:request/5}
 -type error() ::
     {http_error, StatusCode :: pos_integer(), HttpBodyResult :: binary()}

--- a/src/oidcc_token_introspection.erl
+++ b/src/oidcc_token_introspection.erl
@@ -161,7 +161,14 @@ extract_response(TokenMap, #oidcc_client_context{client_id = ClientId}) ->
         end,
     Scope = maps:get(<<"scope">>, TokenMap, <<"">>),
     Username = maps:get(<<"username">>, TokenMap, undefined),
+    TokenType = maps:get(<<"token_type">>, TokenMap, undefined),
     Exp = maps:get(<<"exp">>, TokenMap, undefined),
+    Iat = maps:get(<<"iat">>, TokenMap, undefined),
+    Nbf = maps:get(<<"nbf">>, TokenMap, undefined),
+    Sub = maps:get(<<"sub">>, TokenMap, undefined),
+    Aud = maps:get(<<"aud">>, TokenMap, undefined),
+    Iss = maps:get(<<"iss">>, TokenMap, undefined),
+    Jti = maps:get(<<"jti">>, TokenMap, undefined),
     case maps:get(<<"client_id">>, TokenMap, undefined) of
         IntrospectionClientId when
             IntrospectionClientId == ClientId; IntrospectionClientId == undefined
@@ -171,7 +178,31 @@ extract_response(TokenMap, #oidcc_client_context{client_id = ClientId}) ->
                 scope = oidcc_scope:parse(Scope),
                 client_id = ClientId,
                 username = Username,
-                exp = Exp
+                exp = Exp,
+                token_type = TokenType,
+                iat = Iat,
+                nbf = Nbf,
+                sub = Sub,
+                aud = Aud,
+                iss = Iss,
+                jti = Jti,
+                extra = maps:without(
+                    [
+                        <<"scope">>,
+                        <<"active">>,
+                        <<"username">>,
+                        <<"exp">>,
+                        <<"client_id">>,
+                        <<"token_type">>,
+                        <<"iat">>,
+                        <<"nbf">>,
+                        <<"sub">>,
+                        <<"aud">>,
+                        <<"iss">>,
+                        <<"jti">>
+                    ],
+                    TokenMap
+                )
             }};
         _ ->
             {error, client_id_mismatch}

--- a/test/oidcc_auth_util_test.erl
+++ b/test/oidcc_auth_util_test.erl
@@ -1,0 +1,26 @@
+-module(oidcc_auth_util_test).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("oidcc/include/oidcc_client_context.hrl").
+
+add_client_authentication_no_supported_auth_method_test() ->
+    ?assertMatch(
+        {error, no_supported_auth_method},
+        oidcc_auth_util:add_client_authentication(
+            [], [], undefined, [], #{}, #oidcc_client_context{}
+        )
+    ),
+
+    ?assertMatch(
+        {error, no_supported_auth_method},
+        oidcc_auth_util:add_client_authentication([], [], [], [], #{}, #oidcc_client_context{})
+    ),
+
+    ?assertMatch(
+        {error, no_supported_auth_method},
+        oidcc_auth_util:add_client_authentication(
+            [], [], [<<"client_secret_basic">>], ["HS256"], #{}, #oidcc_client_context{
+                client_secret = unauthenticated
+            }
+        )
+    ).

--- a/test/oidcc_token_introspection_test.erl
+++ b/test/oidcc_token_introspection_test.erl
@@ -31,12 +31,20 @@ introspect_test() ->
             _RequestOpts
         ) ->
             IntrospectionEndpoint = ReqEndpoint,
-            {ok, {{json, #{<<"active">> => true, <<"client_id">> => ClientId}}, []}}
+            {ok,
+                {
+                    {json, #{
+                        <<"active">> => true,
+                        <<"client_id">> => ClientId,
+                        <<"extra">> => <<"value">>
+                    }},
+                    []
+                }}
         end,
     ok = meck:expect(oidcc_http_util, request, HttpFun),
 
     ?assertMatch(
-        {ok, #oidcc_token_introspection{active = true}},
+        {ok, #oidcc_token_introspection{active = true, extra = #{<<"extra">> := <<"value">>}}},
         oidcc_token_introspection:introspect(
             AccessToken,
             ClientContext,

--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -887,13 +887,12 @@ auth_method_client_secret_jwt_no_alg_test() ->
         jose:decode(ConfigurationBinary)
     ),
 
-    #oidcc_provider_configuration{token_endpoint = TokenEndpoint} =
-        Configuration = Configuration0#oidcc_provider_configuration{
-            token_endpoint_auth_methods_supported = [
-                <<"client_secret_jwt">>
-            ],
-            token_endpoint_auth_signing_alg_values_supported = undefined
-        },
+    Configuration = Configuration0#oidcc_provider_configuration{
+        token_endpoint_auth_methods_supported = [
+            <<"client_secret_jwt">>
+        ],
+        token_endpoint_auth_signing_alg_values_supported = undefined
+    },
 
     ClientId = <<"client_id">>,
     ClientSecret = <<"client_secret">>,
@@ -904,41 +903,14 @@ auth_method_client_secret_jwt_no_alg_test() ->
 
     ClientContext = oidcc_client_context:from_manual(Configuration, Jwk, ClientId, ClientSecret),
 
-    ok = meck:new(httpc, [no_link]),
-    HttpFun =
-        fun(
-            post,
-            {ReqTokenEndpoint, _Header, "application/x-www-form-urlencoded", Body},
-            _HttpOpts,
-            _Opts
-        ) ->
-            TokenEndpoint = ReqTokenEndpoint,
-            BodyMap = maps:from_list(uri_string:dissect_query(Body)),
-
-            ClientAssertion = maps:get(<<"client_assertion">>, BodyMap),
-
-            {true, _ClientAssertionJwt, ClientAssertionJws} = jose_jwt:verify(
-                jose_jwk:from_oct(ClientSecret), ClientAssertion
-            ),
-
-            ?assertMatch({jose_jws_alg_hmac, 'HS256'}, ClientAssertionJws#jose_jws.alg),
-
-            {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], <<"{}">>}}
-        end,
-    ok = meck:expect(httpc, request, HttpFun),
-
     ?assertMatch(
-        {ok, #oidcc_token{}},
+        {error, no_supported_auth_method},
         oidcc_token:retrieve(
             AuthCode,
             ClientContext,
             #{redirect_uri => LocalEndpoint}
         )
     ),
-
-    true = meck:validate(httpc),
-
-    meck:unload(httpc),
 
     ok.
 

--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -489,25 +489,22 @@ auth_method_client_secret_jwt_test() ->
             ?assertMatch(none, proplists:lookup("authorization", Header)),
             BodyMap = maps:from_list(uri_string:dissect_query(Body)),
 
-            CharlistAuthCode = binary:bin_to_list(AuthCode),
-            CharlistClientId = binary:bin_to_list(ClientId),
-
             ?assertMatch(
                 #{
-                    "grant_type" := "authorization_code",
-                    "code" := CharlistAuthCode,
-                    "client_id" := CharlistClientId,
-                    "client_assertion_type" :=
-                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                    "client_assertion" := _
+                    <<"grant_type">> := <<"authorization_code">>,
+                    <<"code">> := AuthCode,
+                    <<"client_id">> := ClientId,
+                    <<"client_assertion_type">> :=
+                        <<"urn:ietf:params:oauth:client-assertion-type:jwt-bearer">>,
+                    <<"client_assertion">> := _
                 },
                 BodyMap
             ),
 
-            ClientAssertion = maps:get("client_assertion", BodyMap),
+            ClientAssertion = maps:get(<<"client_assertion">>, BodyMap),
 
             {true, ClientAssertionJwt, ClientAssertionJws} = jose_jwt:verify(
-                jose_jwk:from_oct(ClientSecret), binary:list_to_bin(ClientAssertion)
+                jose_jwk:from_oct(ClientSecret), ClientAssertion
             ),
 
             ?assertMatch(#jose_jws{alg = {jose_jws_alg_hmac, 'HS256'}}, ClientAssertionJws),
@@ -616,10 +613,10 @@ auth_method_client_secret_jwt_with_max_clock_skew_test() ->
             TokenEndpoint = ReqTokenEndpoint,
             BodyMap = maps:from_list(uri_string:dissect_query(Body)),
 
-            ClientAssertion = maps:get("client_assertion", BodyMap),
+            ClientAssertion = maps:get(<<"client_assertion">>, BodyMap),
 
             {true, ClientAssertionJwt, _} = jose_jwt:verify(
-                jose_jwk:from_oct(ClientSecret), binary:list_to_bin(ClientAssertion)
+                jose_jwk:from_oct(ClientSecret), ClientAssertion
             ),
 
             #jose_jwt{
@@ -819,25 +816,22 @@ auth_method_private_key_jwt_test() ->
             ?assertMatch(none, proplists:lookup("authorization", Header)),
             BodyMap = maps:from_list(uri_string:dissect_query(Body)),
 
-            CharlistAuthCode = binary:bin_to_list(AuthCode),
-            CharlistClientId = binary:bin_to_list(ClientId),
-
             ?assertMatch(
                 #{
-                    "grant_type" := "authorization_code",
-                    "code" := CharlistAuthCode,
-                    "client_id" := CharlistClientId,
-                    "client_assertion_type" :=
-                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                    "client_assertion" := _
+                    <<"grant_type">> := <<"authorization_code">>,
+                    <<"code">> := AuthCode,
+                    <<"client_id">> := ClientId,
+                    <<"client_assertion_type">> :=
+                        <<"urn:ietf:params:oauth:client-assertion-type:jwt-bearer">>,
+                    <<"client_assertion">> := _
                 },
                 BodyMap
             ),
 
-            ClientAssertion = maps:get("client_assertion", BodyMap),
+            ClientAssertion = maps:get(<<"client_assertion">>, BodyMap),
 
             {true, ClientAssertionJwt, ClientAssertionJws} = jose_jwt:verify(
-                ClientJwk, binary:list_to_bin(ClientAssertion)
+                ClientJwk, ClientAssertion
             ),
 
             ?assertMatch(
@@ -921,10 +915,10 @@ auth_method_client_secret_jwt_no_alg_test() ->
             TokenEndpoint = ReqTokenEndpoint,
             BodyMap = maps:from_list(uri_string:dissect_query(Body)),
 
-            ClientAssertion = maps:get("client_assertion", BodyMap),
+            ClientAssertion = maps:get(<<"client_assertion">>, BodyMap),
 
             {true, _ClientAssertionJwt, ClientAssertionJws} = jose_jwt:verify(
-                jose_jwk:from_oct(ClientSecret), binary:list_to_bin(ClientAssertion)
+                jose_jwk:from_oct(ClientSecret), ClientAssertion
             ),
 
             ?assertMatch({jose_jws_alg_hmac, 'HS256'}, ClientAssertionJws#jose_jws.alg),


### PR DESCRIPTION
- allow client authentication types other than `client_secret_basic` (by extracting the code used in `oidcc_token`)
- include other values defined in https://datatracker.ietf.org/doc/html/rfc7662, as well as `extra` to include values outside the spec

<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->
