### PR TITLE
two fixes with client JWK signing

### DIFF
--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -207,14 +207,14 @@ attempt_request_object(QueryParams, #oidcc_client_context{
     SigningJwks =
         case oidcc_jwt_util:client_secret_oct_keys(SigningAlgSupported, ClientSecret) of
             none ->
-                Jwks;
+                JwksWithClientJwks;
             SigningOctJwk ->
                 oidcc_jwt_util:merge_jwks(JwksWithClientJwks, SigningOctJwk)
         end,
     EncryptionJwks =
         case oidcc_jwt_util:client_secret_oct_keys(EncryptionAlgSupported, ClientSecret) of
             none ->
-                Jwks;
+                JwksWithClientJwks;
             EncryptionOctJwk ->
                 oidcc_jwt_util:merge_jwks(JwksWithClientJwks, EncryptionOctJwk)
         end,

--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -798,7 +798,9 @@ auth_method_private_key_jwt_test() ->
         }),
 
     ClientJwk0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
-    ClientJwk = ClientJwk0#jose_jwk{fields = #{<<"use">> => <<"sig">>}},
+    ClientJwk = ClientJwk0#jose_jwk{
+        fields = #{<<"kid">> => <<"private_kid">>, <<"use">> => <<"sig">>}
+    },
 
     ClientContext = oidcc_client_context:from_manual(Configuration, Jwk, ClientId, ClientSecret, #{
         client_jwks => ClientJwk
@@ -836,6 +838,14 @@ auth_method_private_key_jwt_test() ->
 
             ?assertMatch(
                 #jose_jws{alg = {_, 'RS256'}}, ClientAssertionJws
+            ),
+
+            #jose_jws{fields = ClientAssertionJwsFields} = ClientAssertionJws,
+            ?assertMatch(
+                #{
+                    <<"kid">> := <<"private_kid">>
+                },
+                ClientAssertionJwsFields
             ),
 
             ?assertMatch(


### PR DESCRIPTION
Two fixes that came up while validating the `private_key_jwt` auth method. With this, it passes the `client-oidcc-test-plan` suite.

<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

<!--
- Please target the oldest branch of oidcc that is still supported and
  affected by this bug.
-->
