### PR TITLE
Introduce Quirks option to allow unsupported grant types

### DIFF
--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -138,6 +138,18 @@ unsupported_grant_type_test() ->
         oidcc_authorization:create_redirect_url(ClientContext, Opts)
     ),
 
+    QuirksOpts =
+        #{
+            redirect_uri => RedirectUri,
+            client_id => ClientId,
+            quirks => #{allow_unsupported_grant_types => true}
+        },
+
+    ?assertMatch(
+        {ok, _},
+        oidcc_authorization:create_redirect_url(ClientContext, QuirksOpts)
+    ),
+
     ok.
 
 create_redirect_url_with_request_object_test() ->


### PR DESCRIPTION
<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

Required for `https://sts.windows.net/{tenant}/` issuer, which does not specify `grant_types_supported` but still offers client credential tokens.