### PR TITLE
feat: `document_overrides` quirk to patch invalid OIDD files

### DIFF
--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -16,17 +16,6 @@
 
 -export_type([error/0]).
 -export_type([opts/0]).
--export_type([quirks/0]).
-
--type quirks() :: #{allow_unsupported_grant_types => boolean()}.
-%% Allow Specification Non-compliance
-%%
-%% <h2>Exceptions</h2>
-%%
-%% <ul>
-%%   <li>`allow_unsupported_grant_types' - Allow to proceed with a grant type
-%%     that has not been registered in `grant_types_supported'</li>
-%% </ul>
 
 -type opts() ::
     #{
@@ -35,8 +24,7 @@
         nonce => binary(),
         pkce_verifier => binary(),
         redirect_uri := uri_string:uri_string(),
-        url_extension => oidcc_http_util:query_params(),
-        quirks => quirks()
+        url_extension => oidcc_http_util:query_params()
     }.
 %% Configure authorization redirect url
 %%
@@ -90,14 +78,7 @@ create_redirect_url(#oidcc_client_context{} = ClientContext, Opts) ->
     } =
         ProviderConfiguration,
 
-    Quirks = maps:get(quirks, Opts, #{}),
-    AllowUnsupportedGrantTypes = maps:get(
-        allow_unsupported_grant_types, Quirks, false
-    ),
-
-    case
-        lists:member(<<"authorization_code">>, GrantTypesSupported) or AllowUnsupportedGrantTypes
-    of
+    case lists:member(<<"authorization_code">>, GrantTypesSupported) of
         true ->
             QueryParams0 = redirect_params(ClientContext, Opts),
             QueryParams = QueryParams0 ++ maps:get(url_extension, Opts, []),

--- a/src/oidcc_provider_configuration.erl
+++ b/src/oidcc_provider_configuration.erl
@@ -33,7 +33,6 @@
 -export_type([t/0]).
 
 -type quirks() :: #{
-    allow_issuer_mismatch => boolean(),
     allow_unsafe_http => boolean(),
     document_overrides => map()
 }.
@@ -42,8 +41,6 @@
 %% <h2>Exceptions</h2>
 %%
 %% <ul>
-%%   <li>`allow_issuer_mismatch' - Allow issuer mismatch between config issuer
-%%     and function parameter</li>
 %%   <li>`allow_unsafe_http' - Allow unsafe HTTP. Use this for development
 %%     providers and <strong>never in production</strong>.</li>
 %%   <li>`document_overrides' - a map to merge with the real OIDD document,
@@ -203,6 +200,7 @@ load_configuration(Issuer0, Opts) ->
     Request = {RequestUrl, []},
 
     Quirks = maps:get(quirks, Opts, #{}),
+    % this quirk is deprecated, but we keep the support for backwards compatibility.
     AllowIssuerMismatch = maps:get(allow_issuer_mismatch, Quirks, false),
 
     maybe

--- a/src/oidcc_provider_configuration.erl
+++ b/src/oidcc_provider_configuration.erl
@@ -34,7 +34,8 @@
 
 -type quirks() :: #{
     allow_issuer_mismatch => boolean(),
-    allow_unsafe_http => boolean()
+    allow_unsafe_http => boolean(),
+    document_overrides => map()
 }.
 %% Allow Specification Non-compliance
 %%
@@ -45,6 +46,8 @@
 %%     and function parameter</li>
 %%   <li>`allow_unsafe_http' - Allow unsafe HTTP. Use this for development
 %%     providers and <strong>never in production</strong>.</li>
+%%   <li>`document_overrides' - a map to merge with the real OIDD document,
+%%     in case the OP left out some values.</li>
 %% </ul>
 
 -type opts() :: #{
@@ -277,9 +280,12 @@ load_jwks(JwksUri, Opts) ->
 %% @since 3.1.0
 -spec decode_configuration(Configuration, Opts) -> {ok, t()} | {error, error()} when
     Configuration :: map(), Opts :: opts().
-decode_configuration(Configuration, Opts) ->
+decode_configuration(Configuration0, Opts) ->
     Quirks = maps:get(quirks, Opts, #{}),
     AllowUnsafeHttp = maps:get(allow_unsafe_http, Quirks, false),
+
+    DocumentOverrides = maps:get(document_overrides, Quirks, #{}),
+    Configuration = maps:merge(Configuration0, DocumentOverrides),
 
     maybe
         {ok, {

--- a/src/oidcc_token.erl
+++ b/src/oidcc_token.erl
@@ -38,7 +38,6 @@
 -export_type([error/0]).
 -export_type([id/0]).
 -export_type([jwt_profile_opts/0]).
--export_type([quirks/0]).
 -export_type([refresh/0]).
 -export_type([refresh_opts/0]).
 -export_type([refresh_opts_no_sub/0]).
@@ -104,8 +103,7 @@
         redirect_uri := uri_string:uri_string(),
         request_opts => oidcc_http_util:request_opts(),
         url_extension => oidcc_http_util:query_params(),
-        body_extension => oidcc_http_util:query_params(),
-        quirks => quirks()
+        body_extension => oidcc_http_util:query_params()
     }.
 %% Options for retrieving a token
 %%
@@ -130,8 +128,7 @@
         refresh_jwks => oidcc_jwt_util:refresh_jwks_for_unknown_kid_fun(),
         request_opts => oidcc_http_util:request_opts(),
         url_extension => oidcc_http_util:query_params(),
-        body_extension => oidcc_http_util:query_params(),
-        quirks => quirks()
+        body_extension => oidcc_http_util:query_params()
     }.
 %% See {@link refresh_opts_no_sub()}
 
@@ -142,8 +139,7 @@
         expected_subject := binary(),
         request_opts => oidcc_http_util:request_opts(),
         url_extension => oidcc_http_util:query_params(),
-        body_extension => oidcc_http_util:query_params(),
-        quirks => quirks()
+        body_extension => oidcc_http_util:query_params()
     }.
 %% Options for refreshing a token
 %%
@@ -164,8 +160,7 @@
     request_opts => oidcc_http_util:request_opts(),
     kid => binary(),
     url_extension => oidcc_http_util:query_params(),
-    body_extension => oidcc_http_util:query_params(),
-    quirks => quirks()
+    body_extension => oidcc_http_util:query_params()
 }.
 
 -type client_credentials_opts() :: #{
@@ -173,19 +168,8 @@
     refresh_jwks => oidcc_jwt_util:refresh_jwks_for_unknown_kid_fun(),
     request_opts => oidcc_http_util:request_opts(),
     url_extension => oidcc_http_util:query_params(),
-    body_extension => oidcc_http_util:query_params(),
-    quirks => quirks()
+    body_extension => oidcc_http_util:query_params()
 }.
-
--type quirks() :: #{allow_unsupported_grant_types => boolean()}.
-%% Allow Specification Non-compliance
-%%
-%% <h2>Exceptions</h2>
-%%
-%% <ul>
-%%   <li>`allow_unsupported_grant_types' - Allow to proceed with a grant type
-%%     that has not been registered in `grant_types_supported'</li>
-%% </ul>
 
 -type error() ::
     {missing_claim, MissingClaim :: binary(), Claims :: oidcc_jwt_util:claims()}
@@ -325,14 +309,7 @@ retrieve(AuthCode, ClientContext, Opts) ->
     #oidcc_provider_configuration{issuer = Issuer, grant_types_supported = GrantTypesSupported} =
         Configuration,
 
-    Quirks = maps:get(quirks, Opts, #{}),
-    AllowUnsupportedGrantTypes = maps:get(
-        allow_unsupported_grant_types, Quirks, false
-    ),
-
-    case
-        lists:member(<<"authorization_code">>, GrantTypesSupported) or AllowUnsupportedGrantTypes
-    of
+    case lists:member(<<"authorization_code">>, GrantTypesSupported) of
         true ->
             PkceVerifier = maps:get(pkce_verifier, Opts, none),
             QsBody =
@@ -416,12 +393,7 @@ refresh(RefreshToken, ClientContext, Opts) ->
     #oidcc_provider_configuration{issuer = Issuer, grant_types_supported = GrantTypesSupported} =
         Configuration,
 
-    Quirks = maps:get(quirks, Opts, #{}),
-    AllowUnsupportedGrantTypes = maps:get(
-        allow_unsupported_grant_types, Quirks, false
-    ),
-
-    case lists:member(<<"refresh_token">>, GrantTypesSupported) or AllowUnsupportedGrantTypes of
+    case lists:member(<<"refresh_token">>, GrantTypesSupported) of
         true ->
             ExpectedSub = maps:get(expected_subject, Opts),
             Scope = maps:get(scope, Opts, []),
@@ -489,15 +461,7 @@ jwt_profile(Subject, ClientContext, Jwk, Opts) ->
     #oidcc_provider_configuration{issuer = Issuer, grant_types_supported = GrantTypesSupported} =
         Configuration,
 
-    Quirks = maps:get(quirks, Opts, #{}),
-    AllowUnsupportedGrantTypes = maps:get(
-        allow_unsupported_grant_types, Quirks, false
-    ),
-
-    case
-        lists:member(<<"urn:ietf:params:oauth:grant-type:jwt-bearer">>, GrantTypesSupported) or
-            AllowUnsupportedGrantTypes
-    of
+    case lists:member(<<"urn:ietf:params:oauth:grant-type:jwt-bearer">>, GrantTypesSupported) of
         true ->
             Iat = os:system_time(seconds),
             Exp = Iat + 60,
@@ -587,14 +551,7 @@ client_credentials(ClientContext, Opts) ->
     #oidcc_provider_configuration{issuer = Issuer, grant_types_supported = GrantTypesSupported} =
         Configuration,
 
-    Quirks = maps:get(quirks, Opts, #{}),
-    AllowUnsupportedGrantTypes = maps:get(
-        allow_unsupported_grant_types, Quirks, false
-    ),
-
-    case
-        lists:member(<<"client_credentials">>, GrantTypesSupported) or AllowUnsupportedGrantTypes
-    of
+    case lists:member(<<"client_credentials">>, GrantTypesSupported) of
         true ->
             Scope = maps:get(scope, Opts, []),
             QueryString = [{<<"grant_type">>, <<"client_credentials">>}],

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -107,51 +107,6 @@ create_redirect_url_test() ->
 
     ok.
 
-unsupported_grant_type_test() ->
-    PrivDir = code:priv_dir(oidcc),
-
-    {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
-    {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
-    ),
-    Configuration = Configuration0#oidcc_provider_configuration{
-        grant_types_supported = []
-    },
-
-    Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
-
-    ClientId = <<"client_id">>,
-    RedirectUri = <<"https://my.server/return">>,
-
-    ClientContext =
-        oidcc_client_context:from_manual(Configuration, Jwks, ClientId, <<"client_secret">>),
-
-    Opts =
-        #{
-            redirect_uri => RedirectUri,
-            client_id => ClientId,
-            url_extension => [{<<"test">>, <<"id">>}]
-        },
-
-    ?assertMatch(
-        {error, {grant_type_not_supported, authorization_code}},
-        oidcc_authorization:create_redirect_url(ClientContext, Opts)
-    ),
-
-    QuirksOpts =
-        #{
-            redirect_uri => RedirectUri,
-            client_id => ClientId,
-            quirks => #{allow_unsupported_grant_types => true}
-        },
-
-    ?assertMatch(
-        {ok, _},
-        oidcc_authorization:create_redirect_url(ClientContext, QuirksOpts)
-    ),
-
-    ok.
-
 create_redirect_url_with_request_object_test() ->
     PrivDir = code:priv_dir(oidcc),
 

--- a/test/oidcc_provider_configuration_test.erl
+++ b/test/oidcc_provider_configuration_test.erl
@@ -576,6 +576,20 @@ allow_unsafe_http_quirk_test() ->
 
     ok.
 
+document_overrides_quirk_test() ->
+    PrivDir = code:priv_dir(oidcc),
+    {ok, Configuration} = file:read_file(PrivDir ++ "/test/fixtures/google-metadata.json"),
+
+    ?assertMatch(
+        {ok, #oidcc_provider_configuration{
+            issuer = <<"https://example.com">>
+        }},
+        oidcc_provider_configuration:decode_configuration(jose:decode(Configuration), #{
+            quirks => #{document_overrides => #{<<"issuer">> => <<"https://example.com">>}}
+        })
+    ),
+    ok.
+
 uri_concatenation_test() ->
     ok = meck:new(httpc, [no_link]),
     HttpFun =


### PR DESCRIPTION
I don't love this as a bulk override, but it seems easier than needing to add a specific quirk for each attribute that it's possible for an OP to get wrong?

<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->
