### PR TITLE
feat: Pushed Authorization Request (PAR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The refactoring for `v3` and the certification is funded as an
 * Authorization (Code Flow)
   * [Request Object](https://openid.net/specs/openid-connect-core-1_0.html#RequestObject)
   * [PKCE](https://oauth.net/2/pkce/)
+  * [Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126)
 * Token
   * Authorization: `client_secret_basic`, `client_secret_post`,
     `client_secret_jwt`, and `private_key_jwt`

--- a/include/oidcc_client_registration.hrl
+++ b/include/oidcc_client_registration.hrl
@@ -65,6 +65,8 @@
     request_uris = undefined :: [uri_string:uri_string()] | undefined,
     %% OpenID Connect RP-Initiated Logout 1.0
     post_logout_redirect_uris = undefined :: [uri_string:uri_string()] | undefined,
+    %% OAuth 2.0 Pushed Authorization Requests
+    require_pushed_authorization_requests = false :: boolean(),
     %% Unknown Fields
     extra_fields = #{} :: #{binary() => term()}
 }).

--- a/lib/oidcc/client_registration.ex
+++ b/lib/oidcc/client_registration.ex
@@ -80,6 +80,7 @@ defmodule Oidcc.ClientRegistration do
           initiate_login_uri: :uri_string.uri_string() | :undefined,
           request_uris: [:uri_string.uri_string()] | :undefined,
           post_logout_redirect_uris: [:uri_string.uri_string()] | :undefined,
+          require_pushed_authorization_requests: boolean(),
           extra_fields: %{String.t() => term()}
         }
 

--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -136,14 +136,14 @@ append_code_challenge(CodeVerifier, QueryParams, ClientContext) ->
                         mode => urlsafe, padding => false
                     }),
                     [
-                        {"code_challenge", CodeChallenge},
-                        {"code_challenge_method", <<"S256">>}
+                        {<<"code_challenge">>, CodeChallenge},
+                        {<<"code_challenge_method">>, <<"S256">>}
                         | QueryParams
                     ];
                 {false, true} ->
                     [
-                        {"code_challenge", CodeVerifier},
-                        {"code_challenge_method", <<"plain">>}
+                        {<<"code_challenge">>, CodeVerifier},
+                        {<<"code_challenge_method">>, <<"plain">>}
                         | QueryParams
                     ];
                 {false, false} ->

--- a/src/oidcc_client_registration.erl
+++ b/src/oidcc_client_registration.erl
@@ -108,6 +108,8 @@
         request_uris :: [uri_string:uri_string()] | undefined,
         %% OpenID Connect RP-Initiated Logout 1.0
         post_logout_redirect_uris :: [uri_string:uri_string()] | undefined,
+        %% OAuth 2.0 Pushed Authorization Requests
+        require_pushed_authorization_requests :: boolean(),
         %% Unknown Fields
         extra_fields :: #{binary() => term()}
     }.
@@ -293,6 +295,7 @@ encode(#oidcc_client_registration{
     initiate_login_uri = InitiateLoginUri,
     request_uris = RequestUris,
     post_logout_redirect_uris = PostLogoutRedirectUris,
+    require_pushed_authorization_requests = RequirePushedAuthorizationRequests,
     extra_fields = ExtraFields
 }) ->
     Map0 = #{
@@ -332,7 +335,8 @@ encode(#oidcc_client_registration{
         default_acr_values => DefaultAcrValues,
         initiate_login_uri => InitiateLoginUri,
         request_uris => RequestUris,
-        post_logout_redirect_uris => PostLogoutRedirectUris
+        post_logout_redirect_uris => PostLogoutRedirectUris,
+        require_pushed_authorization_requests => RequirePushedAuthorizationRequests
     },
     Map1 = maps:merge(Map0, ExtraFields),
     Map = maps:filter(

--- a/test/oidcc_authorization_SUITE.erl
+++ b/test/oidcc_authorization_SUITE.erl
@@ -1,5 +1,8 @@
 -module(oidcc_authorization_SUITE).
 
+-include("oidcc_client_context.hrl").
+-include("oidcc_provider_configuration.hrl").
+
 -export([all/0]).
 -export([create_redirect_url_inl_gov/1]).
 
@@ -14,10 +17,15 @@ create_redirect_url_inl_gov(_Config) ->
             issuer => <<"https://identity-preview.inl.gov">>
         }),
 
-    {ok, ClientContext} = oidcc_client_context:from_configuration_worker(
+    {ok, #oidcc_client_context{provider_configuration = ProviderConfiguration} = ClientContext0} = oidcc_client_context:from_configuration_worker(
         InlGovPid, <<"client_id">>, <<"client_secret">>
     ),
-
+    %% we only want to test the URL generation, not the PAR request
+    ClientContext = ClientContext0#oidcc_client_context{
+        provider_configuration = ProviderConfiguration#oidcc_provider_configuration{
+            pushed_authorization_request_endpoint = undefined
+        }
+    },
     {ok, Url} = oidcc_authorization:create_redirect_url(ClientContext, #{
         redirect_uri => <<"https://my.server/return">>
     }),


### PR DESCRIPTION
RFC: https://datatracker.ietf.org/doc/html/rfc9126

## Open Questions
- [x] what to do if the PAR request fails, but PAR isn't required? Currently, we always use PAR if it's supported, and fail the URL generation if PAR fails.

<!---
name: 🎉 New Feature
about: You have implemented some neat idea that you want to make part of oidcc?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->
