### PR TITLE
fix(PAR): ensure we don't send duplicate parameters

### DIFF
--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -315,7 +315,7 @@ attempt_par(
     AuthenticationOpts = #{audience => Issuer},
 
     maybe
-        {ok, {Body, Header}} ?=
+        {ok, {Body0, Header}} ?=
             oidcc_auth_util:add_client_authentication(
                 QueryParams,
                 Header0,
@@ -324,6 +324,8 @@ attempt_par(
                 AuthenticationOpts,
                 ClientContext
             ),
+        %% ensure no duplicate parameters (such as client_id)
+        Body = lists:ukeysort(1, Body0),
         Request =
             {PushedAuthorizationRequestEndpoint, Header, "application/x-www-form-urlencoded",
                 uri_string:compose_query(Body)},

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -910,7 +910,11 @@ create_redirect_url_with_par_client_secret_jwt_request_object_test() ->
             _HttpOpts,
             _Opts
         ) ->
-            BodyMap = maps:from_list(uri_string:dissect_query(Body)),
+            BodyParsed = uri_string:dissect_query(Body),
+            BodyMap = maps:from_list(BodyParsed),
+
+            %% no duplicate parameters
+            ?assertEqual(length(BodyParsed), map_size(BodyMap)),
 
             ?assertMatch(
                 #{


### PR DESCRIPTION
This wasn't validated by the conformance suite test I was using, nor my unit tests.

<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

<!--
- Please target the oldest branch of oidcc that is still supported and
  affected by this bug.
-->
