### PR TITLE
feat: function to locally validate a JWT

### DIFF
--- a/lib/oidcc/token.ex
+++ b/lib/oidcc/token.ex
@@ -304,6 +304,52 @@ defmodule Oidcc.Token do
       )
 
   @doc """
+  Validate JWT
+
+  Validates a generic JWT (such as an access token) from the given provider.
+  Useful if the issuer is shared between multiple applications, and the access token
+  generated for a user at one client is used to validate their access at another client.
+
+  ## Examples
+
+      iex> {:ok, pid} =
+      ...>   Oidcc.ProviderConfiguration.Worker.start_link(%{
+      ...>     issuer: "https://api.login.yahoo.com"
+      ...>   })
+      ...>
+      ...> {:ok, client_context} =
+      ...>   Oidcc.ClientContext.from_configuration_worker(
+      ...>     pid,
+      ...>     "client_id",
+      ...>     "client_secret"
+      ...>   )
+      ...>
+      ...> #Get JWT from Authorization header
+      ...> jwt = "jwt"
+      ...>
+      ...> opts = %{
+      ...>   signing_algs: client_context.provider_configuration.id_token_signing_alg_values_supported
+      ...> }
+      ...>
+      ...> Oidcc.Token.validate_jwt(jwt, client_context, opts)
+      ...> # => {:ok, %{"sub" => "sub", ... }}
+
+  """
+  @doc since: "3.0.0"
+  @spec validate_jwt(
+          jwt :: String.t(),
+          client_context :: ClientContext.t(),
+          opts :: :oidcc_token.validate_jwt_opts()
+        ) :: {:ok, :oidcc_jwt_util.claims()} | {:error, :oidcc_token.error()}
+  def validate_jwt(jwt, client_context, opts),
+    do:
+      :oidcc_token.validate_jwt(
+        jwt,
+        ClientContext.struct_to_record(client_context),
+        opts
+      )
+
+  @doc """
   Retrieve JSON Web Token (JWT) Profile Token
 
   See https://datatracker.ietf.org/doc/html/rfc7523#section-4

--- a/test/oidcc_token_SUITE.erl
+++ b/test/oidcc_token_SUITE.erl
@@ -5,13 +5,14 @@
 -export([init_per_suite/1]).
 -export([retrieves_client_credentials_token/1]).
 -export([retrieves_jwt_profile_token/1]).
+-export([validates_access_token/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("jose/include/jose_jwk.hrl").
 -include_lib("oidcc/include/oidcc_token.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
-all() -> [retrieves_jwt_profile_token, retrieves_client_credentials_token].
+all() -> [retrieves_jwt_profile_token, retrieves_client_credentials_token, validates_access_token].
 
 init_per_suite(_Config) ->
     {ok, _} = application:ensure_all_started(oidcc),
@@ -109,6 +110,44 @@ retrieves_client_credentials_token(_Config) ->
         oidcc_token:client_credentials(ZitadelClientContext, #{
             scope => [<<"openid">>, <<"profile">>]
         })
+    ),
+
+    ok.
+
+validates_access_token(_Config) ->
+    PrivDir = code:priv_dir(oidcc),
+    Issuer = <<"https://erlef-test-w4a8z2.zitadel.cloud">>,
+
+    {ok, ZitadelConfigurationPid} =
+        oidcc_provider_configuration_worker:start_link(#{
+            issuer => Issuer
+        }),
+
+    {ok, ZitadelClientCredentialsJson} = file:read_file(
+        PrivDir ++ "/test/fixtures/zitadel-client-credentials.json"
+    ),
+    #{
+        <<"clientId">> := ZitadelClientCredentialsClientId,
+        <<"clientSecret">> := ZitadelClientCredentialsClientSecret
+    } = jose:decode(ZitadelClientCredentialsJson),
+
+    {ok, ZitadelClientContext} = oidcc_client_context:from_configuration_worker(
+        ZitadelConfigurationPid,
+        ZitadelClientCredentialsClientId,
+        ZitadelClientCredentialsClientSecret
+    ),
+
+    {ok, Token} = oidcc_token:client_credentials(ZitadelClientContext, #{
+        scope => [<<"openid">>, <<"profile">>]
+    }),
+
+    #oidcc_token{access = #oidcc_token_access{token = AccessToken}} = Token,
+    ?assertMatch(
+        {ok, #{
+            <<"iss">> := Issuer,
+            <<"aud">> := [ZitadelClientCredentialsClientId]
+        }},
+        oidcc_token:validate_jwt(AccessToken, ZitadelClientContext, #{signing_algs => [<<"RS256">>]})
     ),
 
     ok.


### PR DESCRIPTION
Many access tokens are JWTs, which clients can validate without needing to use the `token_introspection` endpoint. This allows multiple clients using the same issuer to use access tokens as a means of validation between them.

<!---
name: 🎉 New Feature
about: You have implemented some neat idea that you want to make part of oidcc?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->
