### PR TITLE
fix: small fixes for DPoP

### DIFF
--- a/lib/oidcc/token/access.ex
+++ b/lib/oidcc/token/access.ex
@@ -33,17 +33,26 @@ defmodule Oidcc.Token.Access do
           endpoint :: String.t(),
           client_context :: ClientContext.t()
         ) :: %{String.t() => String.t()}
+  @spec authorization_headers(
+          access_token :: t(),
+          method :: :get | :post,
+          endpoint :: String.t(),
+          client_context :: ClientContext.t(),
+          opts :: %{optional(:dpop_nonce) => binary()}
+        ) :: %{String.t() => String.t()}
   def authorization_headers(
         access_token,
         method,
         endpoint,
-        client_context
+        client_context,
+        opts \\ %{}
       ),
       do:
         :oidcc_token.authorization_headers(
           struct_to_record(access_token),
           method,
           endpoint,
-          ClientContext.struct_to_record(client_context)
+          ClientContext.struct_to_record(client_context),
+          opts
         )
 end

--- a/lib/oidcc/token/access.ex
+++ b/lib/oidcc/token/access.ex
@@ -38,7 +38,7 @@ defmodule Oidcc.Token.Access do
           method :: :get | :post,
           endpoint :: String.t(),
           client_context :: ClientContext.t(),
-          opts :: %{optional(:dpop_nonce) => binary()}
+          opts :: :oidcc_token.authorization_headers_opts()
         ) :: %{String.t() => String.t()}
   def authorization_headers(
         access_token,

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -153,7 +153,7 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
         end,
     case proplists:lookup("dpop-nonce", Headers) of
         {"dpop-nonce", DpopNonce} ->
-            {error, {use_dpop_nonce, DpopNonce, Body}};
+            {error, {use_dpop_nonce, iolist_to_binary(DpopNonce), Body}};
         _ ->
             {error, {http_error, StatusCode, Body}}
     end.

--- a/src/oidcc_token.erl
+++ b/src/oidcc_token.erl
@@ -38,6 +38,7 @@
 -export([authorization_headers/5]).
 
 -export_type([access/0]).
+-export_type([authorization_headers_opts/0]).
 -export_type([client_credentials_opts/0]).
 -export_type([error/0]).
 -export_type([id/0]).
@@ -187,6 +188,10 @@
     request_opts => oidcc_http_util:request_opts(),
     url_extension => oidcc_http_util:query_params(),
     body_extension => oidcc_http_util:query_params()
+}.
+
+-type authorization_headers_opts() :: #{
+    dpop_nonce => binary()
 }.
 
 -type error() ::
@@ -954,7 +959,7 @@ when
     Method :: post | get,
     Endpoint :: uri_string:uri_string(),
     ClientContext :: oidcc_client_context:t(),
-    Opts :: #{dpop_nonce => binary()},
+    Opts :: authorization_headers_opts(),
     HeaderMap :: #{binary() => binary()}.
 authorization_headers(AccessTokenRecord, Method, Endpoint, ClientContext) ->
     authorization_headers(AccessTokenRecord, Method, Endpoint, ClientContext, #{}).

--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -1259,7 +1259,10 @@ auth_method_private_key_jwt_with_dpop_and_nonce_test() ->
                 _ ->
                     {ok, {
                         {"HTTP/1.1", 400, "OK"},
-                        [{"content-type", "application/json"}, {"dpop-nonce", DpopNonce}],
+                        [
+                            {"content-type", "application/json"},
+                            {"dpop-nonce", binary_to_list(DpopNonce)}
+                        ],
                         DpopNonceError
                     }}
             end

--- a/test/oidcc_userinfo_test.erl
+++ b/test/oidcc_userinfo_test.erl
@@ -871,7 +871,10 @@ dpop_proof_with_nonce_test() ->
                 _ ->
                     {ok, {
                         {"HTTP/1.1", 400, "Bad Request"},
-                        [{"content-type", "application/json"}, {"dpop-nonce", DpopNonce}],
+                        [
+                            {"content-type", "application/json"},
+                            {"dpop-nonce", binary_to_list(DpopNonce)}
+                        ],
                         DpopNonceError
                     }}
             end
@@ -936,7 +939,7 @@ dpop_proof_with_invalid_nonce_test() ->
         fun(get, _UrlHeader, _HttpOpts, _Opts, _Profile) ->
             {ok, {
                 {"HTTP/1.1", 400, "Bad Request"},
-                [{"content-type", "application/json"}, {"dpop-nonce", DpopNonce}],
+                [{"content-type", "application/json"}, {"dpop-nonce", binary_to_list(DpopNonce)}],
                 DpopNonceError
             }}
         end,


### PR DESCRIPTION
https://gitlab.com/openid/conformance-suite/-/merge_requests/1354 has conformance tests which incorporate validation of the DPoP nonces, which uncovered a couple issues:

- we were providing the nonce in the claims as a list of numbers (charlist) instead of a binary
- `Oidcc.Token.Access.authorization_headers` didn't expose `opts` to provide the `dpop_nonce` value

<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

<!--
- Please target the oldest branch of oidcc that is still supported and
  affected by this bug.
-->
