### PR TITLE
feat: small features to support ConnectID.com.au profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The refactoring for `v3` and the certification is funded as an
   * [RP-Initiated](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
 * [JWT Secured Authorization Response Mode for OAuth 2.0 (JARM)](https://openid.net/specs/oauth-v2-jarm-final.html)
 * [Demonstrating Proof of Possession (DPoP)](https://www.rfc-editor.org/rfc/rfc9449)
+* [OAuth 2 Purpose Request Parameter](https://cdn.connectid.com.au/specifications/oauth2-purpose-01.html)
 * Profiles
   * [FAPI 2.0 Security Profile](https://openid.bitbucket.io/fapi/fapi-2_0-security-profile.html)
   * [FAPI 2.0 Message Signing](https://openid.bitbucket.io/fapi/fapi-2_0-message-signing.html)

--- a/src/oidcc_profile.erl
+++ b/src/oidcc_profile.erl
@@ -17,7 +17,7 @@
 -export_type([opts_no_profiles/0]).
 -export_type([error/0]).
 
--type profile() :: fapi2_security_profile | fapi2_message_signing.
+-type profile() :: fapi2_security_profile | fapi2_message_signing | fapi2_connectid_au.
 -type opts() :: #{
     profiles => [profile()],
     require_pkce => boolean(),
@@ -92,6 +92,61 @@ apply_profiles(
     %% Also require everything from FAPI2 Security Profile
     Opts = Opts0#{profiles => [fapi2_security_profile | RestProfiles]},
     apply_profiles(ClientContext, Opts);
+apply_profiles(
+    #oidcc_client_context{} = ClientContext0,
+    #{profiles := [fapi2_connectid_au | RestProfiles]} = Opts0
+) ->
+    %% FAPI2 ConnectID profile
+    maybe
+        %% Require everything from FAPI2 Message Signing
+        {ok, ClientContext1, Opts1} ?=
+            apply_profiles(ClientContext0, Opts0#{
+                profiles => [fapi2_message_signing | RestProfiles]
+            }),
+        %% Require `purpose' field
+        Opts2 = Opts1#{require_purpose => true},
+        %% If a PAR endpoint is present in the mTLS aliases, use that as the default
+        #oidcc_client_context{provider_configuration = Configuration1} = ClientContext1,
+        Configuration2 =
+            case Configuration1#oidcc_provider_configuration.mtls_endpoint_aliases of
+                #{
+                    <<"pushed_authorization_request_endpoint">> := MtlsParEndpoint
+                } ->
+                    Configuration1#oidcc_provider_configuration{
+                        pushed_authorization_request_endpoint = MtlsParEndpoint
+                    };
+                _ ->
+                    Configuration1
+            end,
+        %% If the token endpoint is present in the mTLS aliases, use that as the default
+        Configuration3 =
+            case Configuration2#oidcc_provider_configuration.mtls_endpoint_aliases of
+                #{
+                    <<"token_endpoint">> := MtlsTokenEndpoint
+                } ->
+                    Configuration2#oidcc_provider_configuration{
+                        token_endpoint = MtlsTokenEndpoint
+                    };
+                _ ->
+                    Configuration2
+            end,
+        %% If the userinfo endpoint is present in the mTLS aliases, use that as the default
+        Configuration4 =
+            case Configuration3#oidcc_provider_configuration.mtls_endpoint_aliases of
+                #{
+                    <<"userinfo_endpoint">> := MtlsUserinfoEndpoint
+                } ->
+                    Configuration3#oidcc_provider_configuration{
+                        userinfo_endpoint = MtlsUserinfoEndpoint
+                    };
+                _ ->
+                    Configuration3
+            end,
+        ClientContext2 = ClientContext1#oidcc_client_context{
+            provider_configuration = Configuration4
+        },
+        {ok, ClientContext2, Opts2}
+    end;
 apply_profiles(#oidcc_client_context{}, #{profiles := [UnknownProfile | _]}) ->
     {error, {unknown_profile, UnknownProfile}};
 apply_profiles(#oidcc_client_context{} = ClientContext, #{profiles := []} = Opts0) ->

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -65,6 +65,9 @@ create_redirect_url_test() ->
     Opts5 = maps:merge(BaseOpts, #{pkce_verifier => <<"foo">>}),
     Opts6 = maps:merge(Opts5, #{require_pkce => true}),
     Opts7 = maps:merge(BaseOpts, #{require_pkce => true}),
+    Opts8 = maps:merge(BaseOpts, #{purpose => <<"purpose">>}),
+    Opts9 = maps:merge(Opts8, #{purpose_required => true}),
+    Opts10 = maps:merge(BaseOpts, #{purpose_required => true}),
 
     {ok, Url1} = oidcc_authorization:create_redirect_url(ClientContext, BaseOpts),
     {ok, Url2} = oidcc_authorization:create_redirect_url(ClientContext, Opts1),
@@ -75,6 +78,8 @@ create_redirect_url_test() ->
     {ok, Url7} = oidcc_authorization:create_redirect_url(PkcePlainClientContext, Opts5),
     {ok, Url8} = oidcc_authorization:create_redirect_url(NoPkceClientContext, Opts5),
     {ok, Url9} = oidcc_authorization:create_redirect_url(PkcePlainClientContext, Opts6),
+    {ok, Url10} = oidcc_authorization:create_redirect_url(ClientContext, Opts8),
+    {ok, Url11} = oidcc_authorization:create_redirect_url(ClientContext, Opts9),
 
     ExpUrl1 =
         <<"https://my.provider/auth?scope=openid&response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Fmy.server%2Freturn&test=id">>,
@@ -110,6 +115,12 @@ create_redirect_url_test() ->
 
     ?assertEqual(iolist_to_binary(Url9), iolist_to_binary(Url7)),
 
+    ExpUrl10 =
+        <<"https://my.provider/auth?scope=openid&purpose=purpose&response_type=code&client_id=client_id&redirect_uri=https%3A%2F%2Fmy.server%2Freturn&test=id">>,
+    ?assertEqual(ExpUrl10, iolist_to_binary(Url10)),
+
+    ?assertEqual(iolist_to_binary(Url11), iolist_to_binary(Url10)),
+
     ?assertEqual(
         {error, no_supported_code_challenge},
         oidcc_authorization:create_redirect_url(NoPkceClientContext, Opts6)
@@ -118,6 +129,11 @@ create_redirect_url_test() ->
     ?assertEqual(
         {error, pkce_verifier_required},
         oidcc_authorization:create_redirect_url(ClientContext, Opts7)
+    ),
+
+    ?assertEqual(
+        {error, purpose_required},
+        oidcc_authorization:create_redirect_url(ClientContext, Opts10)
     ),
 
     ok.

--- a/test/oidcc_client_context_test.erl
+++ b/test/oidcc_client_context_test.erl
@@ -163,6 +163,62 @@ apply_profiles_fapi2_message_signing_test() ->
 
     ok.
 
+apply_profiles_fapi2_connectid_au_test() ->
+    ClientContext0 = client_context_fixture(),
+    Opts0 = #{
+        profiles => [fapi2_connectid_au]
+    },
+
+    ProfileResult = oidcc_client_context:apply_profiles(ClientContext0, Opts0),
+
+    ?assertMatch(
+        {ok, #oidcc_client_context{}, #{}},
+        ProfileResult
+    ),
+
+    {ok, ClientContext, Opts} = ProfileResult,
+
+    ?assertMatch(
+        #oidcc_client_context{
+            provider_configuration = #oidcc_provider_configuration{
+                token_endpoint = <<"https://my.provider/tls/token">>,
+                userinfo_endpoint = <<"https://my.provider/tls/userinfo">>,
+                response_types_supported = [<<"code">>],
+                response_modes_supported = [<<"jwt">>, <<"query.jwt">>],
+                id_token_signing_alg_values_supported = [<<"EdDSA">>],
+                userinfo_signing_alg_values_supported = [
+                    <<"PS256">>,
+                    <<"PS384">>,
+                    <<"PS512">>,
+                    <<"ES256">>,
+                    <<"ES384">>,
+                    <<"ES512">>,
+                    <<"EdDSA">>
+                ],
+                code_challenge_methods_supported = [<<"S256">>],
+                require_pushed_authorization_requests = true,
+                pushed_authorization_request_endpoint = undefined,
+                authorization_response_iss_parameter_supported = true
+            }
+        },
+        ClientContext
+    ),
+
+    ?assertMatch(
+        #{
+            preferred_auth_methods := [private_key_jwt, tls_client_auth],
+            require_pkce := true,
+            require_purpose := true,
+            trusted_audiences := [],
+            request_opts := #{
+                ssl := _
+            }
+        },
+        Opts
+    ),
+
+    ok.
+
 apply_profiles_unknown_test() ->
     ClientContext = client_context_fixture(),
     Opts = #{


### PR DESCRIPTION
I can't find any good documentation about it, but this is what's necessary to pass the conformance suite:

- require a "purpose" value in the request
- use the mTLS endpoints (with a certificate) even if we're not using mTLS authentication

<!---
name: 🎉 New Feature
about: You have implemented some neat idea that you want to make part of oidcc?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->
