### PR TITLE
Always refresh keys on empty JWK

### DIFF
--- a/src/oidcc_provider_configuration_worker.erl
+++ b/src/oidcc_provider_configuration_worker.erl
@@ -148,6 +148,11 @@ handle_cast(refresh_configuration, State) ->
     {noreply, State, {continue, load_configuration}};
 handle_cast(refresh_jwks, State) ->
     {noreply, State, {continue, load_jwks}};
+handle_cast(
+    {refresh_jwks_for_unknown_kid, _Kid},
+    #state{jwks = #jose_jwk{keys = {jose_jwk_set, []}}} = State
+) ->
+    {noreply, State, {continue, load_jwks}};
 handle_cast({refresh_jwks_for_unknown_kid, Kid}, #state{jwks = Jwks} = State) ->
     case has_kid(Jwks, Kid) of
         false ->

--- a/test/oidcc_provider_configuration_worker_test.erl
+++ b/test/oidcc_provider_configuration_worker_test.erl
@@ -62,3 +62,60 @@ retries_with_backoff_with_invalid_issuer_test() ->
     meck:unload(httpc),
 
     ok.
+
+refreshes_with_empty_key_set_test() ->
+    ok = meck:new(httpc, [no_link]),
+    HttpFun =
+        fun
+            (
+                get,
+                {"https://example.com/.well-known/openid-configuration", []},
+                _HttpOpts,
+                _Opts,
+                _Profile
+            ) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [{"content-type", "application/json"}],
+                    jsx:encode(#{
+                        issuer => <<"https://example.com">>,
+                        jwks_uri => <<"https://example.com/keys">>,
+                        authorization_endpoint => <<"https://example.com/authorize">>,
+                        scopes_supported => [<<"openid">>],
+                        response_types_supported => [<<"code">>],
+                        subject_types_supported => [<<"public">>],
+                        id_token_signing_alg_values_supported => [<<"RS256">>]
+                    })
+                }};
+            (
+                get,
+                {<<"https://example.com/keys">>, []},
+                _HttpOpts,
+                _Opts,
+                _Profile
+            ) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [{"content-type", "application/json"}],
+                    jsx:encode(#{keys => []})
+                }}
+        end,
+    ok = meck:expect(httpc, request, HttpFun),
+
+    process_flag(trap_exit, true),
+
+    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
+        issuer => <<"https://example.com">>,
+        backoff_type => random,
+        backoff_min => 500,
+        backoff_max => 500
+    }),
+
+    ok = oidcc_provider_configuration_worker:refresh_jwks_for_unknown_kid(Pid, <<"kid">>),
+
+    % Once for Metadata, once for JWKs, and once for JWK refresh
+    ?assert(meck:num_calls(httpc, request, '_') >= 3),
+
+    meck:unload(httpc),
+
+    ok.


### PR DESCRIPTION
<!---
name: 🐞 Bug Fix
about: You have a fix for a bug?
labels: bug
--->

<!--
- Please target the oldest branch of oidcc that is still supported and
  affected by this bug.
-->

Given an empty key set, the logic to prevent refreshes for keys without `kid` triggers and are never reloaded. This changes the logic so that an empty set always refreshes.
