### PR TITLE
Fix `-define` typo in oidcc.hrl

### DIFF
--- a/include/oidcc.hrl
+++ b/include/oidcc.hrl
@@ -5,6 +5,6 @@
 -include("oidcc_client_registration.hrl").
 -include("oidcc_token.hrl").
 
--defined(OIDCC_HRL, 1).
+-define(OIDCC_HRL, 1).
 
 -endif.


### PR DESCRIPTION
The typo caused an error when compiling projects that include oidcc.hrl.
