### PR TITLE
Accept issuer with and without trailing slash

### DIFF
--- a/src/oidcc_provider_configuration.erl
+++ b/src/oidcc_provider_configuration.erl
@@ -203,13 +203,14 @@ when
 load_configuration(Issuer0, Opts) ->
     Issuer = iolist_to_binary(Issuer0),
     % Accept issuer with and without trailing "/"
-    Issuer1 = case binary:last(Issuer) of
-        $/ ->
-            <<X:(size(Issuer)-1)/binary, $/>> = Issuer,
-            X;
-        _ ->
-            <<Issuer/binary, $/>>
-    end,
+    Issuer1 =
+        case binary:last(Issuer) of
+            $/ ->
+                <<X:(size(Issuer) - 1)/binary, $/>> = Issuer,
+                X;
+            _ ->
+                <<Issuer/binary, $/>>
+        end,
 
     TelemetryOpts = #{topic => [oidcc, load_configuration], extra_meta => #{issuer => Issuer}},
     RequestOpts = maps:get(request_opts, Opts, #{}),


### PR DESCRIPTION
<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

When fetching the configuration, accept an issuer with and without a trailing `/` on the URL.

This fixes an inconsistency between OIDCC providers where sometimes they _need_ a trailing `/` (Auth0) and sometimes they _do not_ want a trailing `/` (Surfconext).

After this patch returned issuers with and without trailing `/` are accepted.

<!--
- Please target the `main` branch of oidcc.
-->
