### PR TITLE
Support `application/jwk-set+json` content-type

### DIFF
--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -161,6 +161,8 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
 -spec fetch_content_type(Headers) -> json | jwt | unknown when Headers :: [http_header()].
 fetch_content_type(Headers) ->
     case proplists:lookup("content-type", Headers) of
+        {"content-type", "application/jwk-set+json" ++ _Rest} ->
+            json;
         {"content-type", "application/json" ++ _Rest} ->
             json;
         {"content-type", "application/jwt" ++ _Rest} ->


### PR DESCRIPTION
Some providers will return this content-type, which is just a JSON content-type with stronger guarantees, so it's safe to just treat it as regular JSON

https://webconcepts.info/concepts/media-type/application/jwk-set+json

<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->
