### PR TITLE
Remove duplicate return type in create_redirect_url spec

### DIFF
--- a/lib/oidcc.ex
+++ b/lib/oidcc.ex
@@ -50,7 +50,7 @@ defmodule Oidcc do
           opts :: :oidcc_authorization.opts() | :oidcc_client_context.opts()
         ) ::
           {:ok, :uri_string.uri_string()}
-          | {:error, :oidcc_client_context.error() | :oidcc_client_context.error()}
+          | {:error, :oidcc_client_context.error()}
   def create_redirect_url(provider_configuration_name, client_id, client_secret, opts),
     do: :oidcc.create_redirect_url(provider_configuration_name, client_id, client_secret, opts)
 


### PR DESCRIPTION
<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

While using `oidcc`, I noticed that one of the return types is duplicated. I wouldn't really define it as a bug, so I labelled it as an "improvement". 😄 

<!--
- Please target the `main` branch of oidcc.
-->
