### PR TITLE
Don't send the same parameters in query string and JWT for PAR request

### DIFF
--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -435,9 +435,6 @@ essential_params(QueryParams) ->
     lists:filter(
         fun
             ({<<"scope">>, _Value}) -> true;
-            ({<<"response_type">>, _Value}) -> true;
-            ({<<"client_id">>, _Value}) -> true;
-            ({<<"redirect_uri">>, _Value}) -> true;
             (_Other) -> false
         end,
         QueryParams

--- a/test/oidcc_authorization_SUITE.erl
+++ b/test/oidcc_authorization_SUITE.erl
@@ -42,15 +42,9 @@ create_redirect_url_inl_gov(_Config) ->
     ),
     QueryParams = maps:from_list(QueryParams1),
 
-    ?assertMatch(
-        #{
-            <<"client_id">> := <<"client_id">>,
-            <<"redirect_uri">> := <<"https://my.server/return">>,
-            <<"response_type">> := <<"code">>,
-            <<"scope">> := <<"openid">>,
-            <<"request">> := _
-        },
-        QueryParams
-    ),
+    ?assertMatch(#{
+                   <<"scope">> := <<"openid">>,
+                   <<"request">> := _
+                  }, QueryParams),
 
     ok.


### PR DESCRIPTION
I tried using version 3.2.0 of this library along with oidcc_plug to authenticate my users via Okta and got the following error when the library would send the PAR to Okta:

    %{"error" => "invalid_request", "error_description" => "The request contained multiple parameters with the same name."}

At first I was confused because I didn't see any duplicate parameters. In the query string I had: `client_id`, `client_secret`, `redirect_uri`, `request`, `response_type`, `scope`. 

And the JWT there was:  `aud`, `client_id`, `code_challenge`, `code_challenge_method`, `exp`, `iat`, `iss`, `jti`, `nbf`, `nonce`, `redirect_uri`, `response_type`, `scope`.

No duplicates in either list.

Then I read [OAuth 2.0 Pushed Authorization Requests - RFC-9126 section 3](https://datatracker.ietf.org/doc/html/rfc9126#section-3):

> The rules for processing, signing, and encryption of the Request Object as defined in JAR [[RFC9101](https://datatracker.ietf.org/doc/html/rfc9101)] apply. Request parameters required by a given client authentication method are included in the application/x-www-form-urlencoded request directly and are the only parameters other than request in the form body (e.g., mutual TLS client authentication [[RFC8705](https://datatracker.ietf.org/doc/html/rfc8705)] uses the client_id HTTP request parameter, while JWT assertion-based client authentication [[RFC7523](https://datatracker.ietf.org/doc/html/rfc7523)] uses client_assertion and client_assertion_type). **All other request parameters, i.e., those pertaining to the authorization request itself, MUST appear as claims of the JWT representing the authorization request.**

So at the very least the query string parameters must be a **subset** of the fields in the JWT.

Then I looked at the [OpenID Connect spec](https://openid.net/specs/openid-connect-core-1_0.html#RequestObject):

> When the request parameter is used, the OpenID Connect **request parameter values contained in the JWT supersede those passed using the OAuth 2.0 request syntax**. However, parameters MAY also be passed using the OAuth 2.0 request syntax even when a Request Object is used; this would typically be done to enable a cached, pre-signed (and possibly pre-encrypted) Request Object value to be used containing the fixed request parameters, while parameters that can vary with each request, such as state and nonce, are passed as OAuth 2.0 parameters. 

I'm not familiar with the "OAuth 2.0 request syntax", but this leads me to believe that if a field is present in both the request JWT and the query string the query string parameter is ignored. If that is the case it can be omitted from the query string. However, it appears the `scope` parameter may always be required:

> Even if a scope parameter is present in the Request Object value, a scope parameter MUST always be passed using the OAuth 2.0 request syntax containing the openid scope value to indicate to the underlying OAuth 2.0 logic that this is an OpenID Connect request.

The changes in this PR allow me to send requests to Okta that it accepts as valid. I'm new to the the OIDC spec so I can't say if this is a bug with Okta or this library.