### PR TITLE
token introspect remove client id constraint

### DIFF
--- a/test/oidcc_token_introspection_test.erl
+++ b/test/oidcc_token_introspection_test.erl
@@ -61,6 +61,15 @@ introspect_test() ->
         )
     ),
 
+    ?assertMatch(
+        {ok, #oidcc_token_introspection{active = true}},
+        oidcc_token_introspection:introspect(
+            #oidcc_token{access = #oidcc_token_access{token = AccessToken}},
+            ClientContext,
+            #{client_self_only => true}
+        )
+    ),
+
     true = meck:validate(oidcc_http_util),
 
     meck:unload(oidcc_http_util),
@@ -180,6 +189,66 @@ introspection_invalid_client_id_test() ->
             AccessToken,
             ClientContext,
             #{}
+        )
+    ),
+
+    true = meck:validate(oidcc_http_util),
+
+    meck:unload(oidcc_http_util),
+
+    ok.
+
+introspection_issuer_client_id_test() ->
+    PrivDir = code:priv_dir(oidcc),
+
+    {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+    {ok,
+        #oidcc_provider_configuration{
+           introspection_endpoint = IntrospectionEndpoint,
+           issuer = Issuer
+          } =
+            Configuration} =
+        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+
+    Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
+
+    OtherClientId = <<"other_client_id">>,
+    MyClientId = <<"my_client_id">>,
+    ClientSecret = <<"client_secret">>,
+    AccessToken = <<"access_token">>,
+
+    ClientContext = oidcc_client_context:from_manual(
+        Configuration, Jwks, MyClientId, ClientSecret
+    ),
+
+    ok = meck:new(oidcc_http_util, [passthrough]),
+    HttpFun =
+        fun(
+            post,
+            {ReqEndpoint, _Header, "application/x-www-form-urlencoded", _Body},
+            _TelemetryOpts,
+            _RequestOpts
+        ) ->
+            IntrospectionEndpoint = ReqEndpoint,
+            {ok, {{json, #{<<"active">> => true, <<"client_id">> => OtherClientId, <<"iss">> => Issuer}}, []}}
+        end,
+    ok = meck:expect(oidcc_http_util, request, HttpFun),
+
+    ?assertMatch(
+        {ok, #oidcc_token_introspection{active = true, client_id = OtherClientId, iss = Issuer}},
+        oidcc_token_introspection:introspect(
+            #oidcc_token{access = #oidcc_token_access{token = AccessToken}},
+            ClientContext,
+            #{client_self_only => false}
+        )
+    ),
+
+    ?assertMatch(
+        {error, client_id_mismatch},
+        oidcc_token_introspection:introspect(
+            AccessToken,
+            ClientContext,
+            #{client_self_only => true}
         )
     ),
 

--- a/test/oidcc_token_introspection_test.erl
+++ b/test/oidcc_token_introspection_test.erl
@@ -204,9 +204,9 @@ introspection_issuer_client_id_test() ->
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok,
         #oidcc_provider_configuration{
-           introspection_endpoint = IntrospectionEndpoint,
-           issuer = Issuer
-          } =
+            introspection_endpoint = IntrospectionEndpoint,
+            issuer = Issuer
+        } =
             Configuration} =
         oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
 
@@ -230,7 +230,13 @@ introspection_issuer_client_id_test() ->
             _RequestOpts
         ) ->
             IntrospectionEndpoint = ReqEndpoint,
-            {ok, {{json, #{<<"active">> => true, <<"client_id">> => OtherClientId, <<"iss">> => Issuer}}, []}}
+            {ok,
+                {
+                    {json, #{
+                        <<"active">> => true, <<"client_id">> => OtherClientId, <<"iss">> => Issuer
+                    }},
+                    []
+                }}
         end,
     ok = meck:expect(oidcc_http_util, request, HttpFun),
 


### PR DESCRIPTION
<!--name: 🐞 Bug Fix
about: introspect unable to work with tokens from other clients of same issuer
labels: bug token introspect-->

resolves #364 

previously could only introspect a client_id's own token, introspect needs to be able to introspect any token for an issuer.

It is my understanding from https://datatracker.ietf.org/doc/html/rfc7662 that introspect endpoint is valid for use with any token from the issuer, however the code prior to this change would reject a token when the client_id in the token was not the same as the client_id of the caller to introspect.