### PR TITLE
fix: partially revert "Don't send the same parameters in query string and JWT for redirect URL (#360)"

### DIFF
--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -447,6 +447,8 @@ essential_params(QueryParams) ->
     lists:filter(
         fun
             ({<<"scope">>, _Value}) -> true;
+            ({<<"response_type">>, _Value}) -> true;
+            ({<<"client_id">>, _Value}) -> true;
             (_Other) -> false
         end,
         QueryParams

--- a/test/oidcc_authorization_SUITE.erl
+++ b/test/oidcc_authorization_SUITE.erl
@@ -44,6 +44,8 @@ create_redirect_url_inl_gov(_Config) ->
 
     ?assertMatch(
         #{
+            <<"client_id">> := <<"client_id">>,
+            <<"response_type">> := <<"code">>,
             <<"scope">> := <<"openid">>,
             <<"request">> := _
         },

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -211,6 +211,8 @@ create_redirect_url_with_request_object_test() ->
 
     ?assertMatch(
         #{
+            <<"client_id">> := <<"client_id">>,
+            <<"response_type">> := <<"code">>,
             <<"scope">> := <<"openid">>,
             <<"should_be_in">> := <<"both">>,
             <<"request">> := _


### PR DESCRIPTION
This reverts partially commit 3b0b5221a0c88ad733a3ffc769b5acada70c2afd.

This commit started to fail the OIDC conformance suite: https://gitlab.com/paulswartz/ueberauth_oidcc_certification/-/pipelines/1391557144

In particular, the error is:

Required http request parameters and request object claims must match

```
Required parameter 'response_type' was not found in http request parameters
Required parameter 'client_id' was not found in http request parameters
```

`redirect_url` does not appear to be required, so we continue to leave that out.