### PR TITLE
build: update elixir tool version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 erlang 27.0.1
 rebar 3.24.0
-elixir 1.17.2
+elixir 1.17.2-otp-27


### PR DESCRIPTION
The default 1.17.2 version from hex is built with OTP 25.  `mix test` has a failure with this version.  

```
  1) test &Oidcc.client_credentials_token/2 works (Oidcc.TokenTest)
     test/oidcc/token_test.exs:211
     match (=) failed
     code:  assert {:ok, %Token{}} =
              Oidcc.Token.client_credentials(
                client_context,
                %{scope: ["openid"]}
              )
     left:  {:ok, %Oidcc.Token{}}
     right: {:error, :no_matching_key}
     stacktrace:
       test/oidcc/token_test.exs:224: (test)
```

Updating to the OTP 27 build resolves this issue.
