### PR TITLE
feat: set `aud` claim to Issuer for FAPI2 profiles

### DIFF
--- a/src/oidcc_token.erl
+++ b/src/oidcc_token.erl
@@ -124,6 +124,8 @@ See https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3.
 * `dpop_nonce` - if using DPoP, the `nonce` value to use in the proof claim.
 * `trusted_audiences` - if present, a list of additional audience values to
   accept. Defaults to `any` which allows any additional values.
+* `jwt_aud_as_issuer` - whether to use the issuer as the audience for JWTs.
+  Defaults to false.
 """).
 ?DOC(#{since => <<"3.0.0">>}).
 -type retrieve_opts() ::
@@ -139,7 +141,8 @@ See https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3.
         url_extension => oidcc_http_util:query_params(),
         body_extension => oidcc_http_util:query_params(),
         dpop_nonce => binary(),
-        trusted_audiences => [binary()] | any
+        trusted_audiences => [binary()] | any,
+        jwt_aud_as_issuer => boolean()
     }.
 
 ?DOC("See `t:refresh_opts_no_sub/0`.").

--- a/test/oidcc_client_context_test.erl
+++ b/test/oidcc_client_context_test.erl
@@ -60,6 +60,7 @@ apply_profiles_fapi2_security_profile_test() ->
             preferred_auth_methods := [private_key_jwt, tls_client_auth],
             require_pkce := true,
             trusted_audiences := [],
+            jwt_aud_as_issuer := true,
             request_opts := #{
                 ssl := _
             }
@@ -154,6 +155,7 @@ apply_profiles_fapi2_message_signing_test() ->
             preferred_auth_methods := [private_key_jwt, tls_client_auth],
             require_pkce := true,
             trusted_audiences := [],
+            jwt_aud_as_issuer := true,
             request_opts := #{
                 ssl := _
             }


### PR DESCRIPTION
At some point, this became part of the spec:

https://openid.bitbucket.io/fapi/fapi-security-profile-2_0.html#section-5.3.1

> Authorization servers [...] shall only accept its issuer identifier value (as defined in [RFC8414]) as a string in the aud claim received in client authentication assertions;

We add a parameter to control this, and set it as a part of the FAPI2 profiles.

<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->

- [ ] I'm not wedded to the name of the option if others have a better idea.
- [ ] Maybe this is a `fix` not a `feat`?