### PR TITLE
Add pluggable HTTP client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,45 @@ mix oidcc.gen.provider_configuration_worker \
 
 <!-- tabs-close -->
 
+## Options
+
+### HTTP Client
+
+By default, oidcc uses Erlang's built-in `httpc`. To use an alternative HTTP
+client, configure `http_client` in `provider_configuration_opts`:
+
+<!-- tabs-open -->
+
+### Erlang
+
+```erlang
+oidcc_provider_configuration_worker:start_link(#{
+    issuer => <<"https://accounts.google.com">>,
+    name => {local, myapp_oidcc_config_provider},
+    provider_configuration_opts => #{
+        request_opts => #{http_client => my_http_client}
+    }
+}).
+```
+
+### Elixir
+
+Using the included Req adapter (requires `{:req, "~> 0.5"}` dependency):
+
+```elixir
+Oidcc.ProviderConfiguration.Worker.start_link(%{
+  issuer: "https://accounts.google.com",
+  name: Myapp.OidccConfigProvider,
+  provider_configuration_opts: %{
+    request_opts: %{http_client: Oidcc.HttpClient.Req}
+  }
+})
+```
+
+<!-- tabs-close -->
+
+See `oidcc_http_client` / `Oidcc.HttpClient` for implementing custom adapters.
+
 ## Usage
 
 <!-- tabs-open -->

--- a/lib/oidcc/http_client.ex
+++ b/lib/oidcc/http_client.ex
@@ -1,0 +1,103 @@
+defmodule Oidcc.HttpClient do
+  @moduledoc """
+  HTTP Client behaviour for OIDC requests.
+
+  Implement this behaviour to use a custom HTTP client with oidcc.
+  By default, oidcc uses Erlang's built-in `httpc` via `:oidcc_http_client_httpc`.
+
+  ## Included Implementations
+
+  * `:oidcc_http_client_httpc` - Default, uses Erlang's built-in `httpc`
+  * `Oidcc.HttpClient.Req` - Uses [Req](https://hex.pm/packages/req) (requires `{:req, "~> 0.5"}` dependency)
+
+  ## Configuration
+
+  Set as application config:
+
+      # config/config.exs
+      config :oidcc, http_client: Oidcc.HttpClient.Req
+
+  Or per-request via `request_opts`:
+
+      Oidcc.ProviderConfiguration.Worker.start_link(%{
+        issuer: "https://example.com",
+        provider_configuration_opts: %{
+          request_opts: %{http_client: Oidcc.HttpClient.Req}
+        }
+      })
+
+  ## Implementing a Custom Client
+
+  See `Oidcc.HttpClient.Req` for a complete implementation example.
+
+  Key considerations:
+
+  * Convert `url` to string - it may be an Erlang charlist
+  * Normalize request headers from charlists to strings
+  * Return response headers as `[{charlist(), charlist()}]` (lowercase keys)
+  * Return the raw response body as binary (set `decode_body: false` or equivalent)
+
+  For Erlang examples, see `:oidcc_http_client`.
+  """
+  @moduledoc since: "3.8.0"
+
+  @typedoc """
+  HTTP request specification.
+
+  * `:method` - HTTP method
+  * `:url` - Request URL
+  * `:headers` - Request headers as list of tuples
+  * `:body` - Optional request body (for POST, PUT, PATCH)
+  """
+  @typedoc since: "3.8.0"
+  @type request :: %{
+          required(:method) => :head | :get | :put | :patch | :post | :trace | :options | :delete,
+          required(:url) => :uri_string.uri_string(),
+          required(:headers) => [{String.t() | charlist(), iodata()}],
+          optional(:body) => iodata()
+        }
+
+  @typedoc """
+  HTTP response specification.
+
+  * `:status` - HTTP status code
+  * `:headers` - Response headers as list of tuples
+  * `:body` - Response body as binary
+  """
+  @typedoc since: "3.8.0"
+  @type response :: %{
+          required(:status) => pos_integer(),
+          required(:headers) => [{String.t() | charlist(), iodata()}],
+          required(:body) => binary()
+        }
+
+  @typedoc """
+  Options passed to the HTTP client implementation.
+
+  Standard options:
+  * `:timeout` - Request timeout in milliseconds
+  * `:ssl` - SSL/TLS options (see `:ssl.tls_option()`)
+
+  For the default `:oidcc_http_client_httpc`:
+  * `:httpc_profile` - httpc profile to use
+  """
+  @typedoc since: "3.8.0"
+  @type opts :: %{
+          optional(:timeout) => timeout(),
+          optional(:ssl) => [:ssl.tls_option()],
+          optional(:httpc_profile) => atom() | pid(),
+          optional(atom()) => term()
+        }
+
+  @doc """
+  Perform an HTTP request.
+
+  The implementation should:
+  1. Execute the HTTP request according to `request`
+  2. Return `{:ok, response}` on success (HTTP 1xx-5xx)
+  3. Return `{:error, reason}` on connection/transport errors
+  """
+  @doc since: "3.8.0"
+  @callback request(request :: request(), opts :: opts()) ::
+              {:ok, response()} | {:error, term()}
+end

--- a/lib/oidcc/http_client/req.ex
+++ b/lib/oidcc/http_client/req.ex
@@ -1,0 +1,95 @@
+if Code.ensure_loaded?(Req) do
+  defmodule Oidcc.HttpClient.Req do
+    @moduledoc """
+    HTTP client implementation using Req.
+
+    This module is only available when `req` is included as a dependency in your project.
+
+    ## Installation
+
+    Add `req` to your dependencies in `mix.exs`:
+
+        {:req, "~> 0.5"}
+
+    ## Usage
+
+    Configure as the default HTTP client:
+
+        # config/config.exs
+        config :oidcc, http_client: Oidcc.HttpClient.Req
+
+    Or use per-request:
+
+        Oidcc.ProviderConfiguration.Worker.start_link(%{
+          issuer: "https://example.com",
+          provider_configuration_opts: %{
+            request_opts: %{http_client: Oidcc.HttpClient.Req}
+          }
+        })
+
+    ## Options
+
+    Standard options from `Oidcc.HttpClient`:
+    * `:timeout` - Request timeout in milliseconds (default: 1 minute)
+    * `:ssl` - SSL/TLS options (passed to Req's `:connect_options`)
+    """
+    @moduledoc since: "3.8.0"
+
+    @behaviour Oidcc.HttpClient
+
+    @impl true
+    def request(request, opts) do
+      %{method: method, url: url, headers: headers} = request
+      body = Map.get(request, :body)
+      timeout = Map.get(opts, :timeout, :timer.minutes(1))
+
+      req_opts =
+        [
+          method: method,
+          url: to_string(url),
+          headers: normalize_request_headers(headers),
+          body: body,
+          receive_timeout: timeout,
+          decode_body: false
+        ]
+        |> maybe_add_ssl_opts(opts)
+
+      case Req.request(req_opts) do
+        {:ok, %Req.Response{status: status, headers: resp_headers, body: resp_body}} ->
+          {:ok,
+           %{
+             status: status,
+             headers: normalize_response_headers(resp_headers),
+             body: resp_body
+           }}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+
+    defp maybe_add_ssl_opts(req_opts, %{ssl: ssl_opts}) when is_list(ssl_opts) do
+      Keyword.put(req_opts, :connect_options, ssl: ssl_opts)
+    end
+
+    defp maybe_add_ssl_opts(req_opts, _opts), do: req_opts
+
+    # Convert request headers from Erlang charlists to Elixir strings
+    defp normalize_request_headers(headers) do
+      Enum.map(headers, fn {key, value} ->
+        {to_string(key), to_string(value)}
+      end)
+    end
+
+    # Req returns headers as a map %{binary => [binary]}
+    # We need to convert them to [{charlist, charlist}] to match httpc format
+    # that oidcc_http_util expects
+    defp normalize_response_headers(headers) when is_map(headers) do
+      Enum.flat_map(headers, fn {key, values} ->
+        Enum.map(List.wrap(values), fn value ->
+          {to_charlist(String.downcase(key)), to_charlist(value)}
+        end)
+      end)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,8 @@ defmodule Oidcc.Mixfile do
       {:ex_doc, "~> 0.29", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: :dev, runtime: false},
       {:dialyxir, "~> 1.4", only: :dev, runtime: false},
-      {:igniter, "~> 0.6.3", optional: true}
+      {:igniter, "~> 0.6.3", optional: true},
+      {:req, "~> 0.5", optional: true}
     ]
   end
 

--- a/src/oidcc.app.src
+++ b/src/oidcc.app.src
@@ -3,7 +3,10 @@
     {vsn, "3.7.0"},
     {registered, []},
     {applications, [kernel, stdlib, inets, ssl, public_key, telemetry, jose]},
-    {env, []},
+    {env, [
+        %% Optional: Custom HTTP client module implementing oidcc_http_client behaviour
+        %% {http_client, oidcc_http_client_httpc}
+    ]},
     {modules, []},
     {licenses, ["Apache-2.0"]},
     {links, []}

--- a/src/oidcc_http_client.erl
+++ b/src/oidcc_http_client.erl
@@ -1,0 +1,111 @@
+-module(oidcc_http_client).
+
+-feature(maybe_expr, enable).
+
+-include("internal/doc.hrl").
+?MODULEDOC("""
+HTTP Client Behaviour for OIDC requests.
+
+Implement this behaviour to use a custom HTTP client with oidcc.
+
+## Example
+
+```erlang
+-module(my_hackney_client).
+-behaviour(oidcc_http_client).
+-export([request/2]).
+
+request(#{method := Method, url := Url, headers := Headers} = Request, Opts) ->
+    Body = maps:get(body, Request, <<>>),
+    Timeout = maps:get(timeout, Opts, 60000),
+
+    case hackney:request(Method, Url, Headers, Body, [{recv_timeout, Timeout}]) of
+        {ok, Status, RespHeaders, ClientRef} ->
+            {ok, RespBody} = hackney:body(ClientRef),
+            {ok, #{status => Status, headers => RespHeaders, body => RespBody}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+```
+
+## Configuration
+
+Set as application config:
+
+```erlang
+application:set_env(oidcc, http_client, my_hackney_client).
+```
+
+Or per-request via `request_opts`:
+
+```erlang
+oidcc_provider_configuration:load_configuration(Issuer, #{
+    request_opts => #{http_client => my_hackney_client}
+}).
+```
+""").
+?MODULEDOC(#{since => <<"3.8.0">>}).
+
+-export_type([request/0, response/0, header/0, http_client/0, http_client_opts/0, error/0]).
+
+?DOC("HTTP request specification").
+?DOC(#{since => <<"3.8.0">>}).
+-type request() :: #{
+    method := head | get | put | patch | post | trace | options | delete,
+    url := uri_string:uri_string(),
+    headers := [header()],
+    body => iodata()
+}.
+
+?DOC("HTTP header tuple").
+?DOC(#{since => <<"3.8.0">>}).
+-type header() :: {binary() | string(), iodata()}.
+
+?DOC("HTTP response specification").
+?DOC(#{since => <<"3.8.0">>}).
+-type response() :: #{
+    status := pos_integer(),
+    headers := [header()],
+    body := binary()
+}.
+
+?DOC("HTTP client module or tuple with module and extra options").
+?DOC(#{since => <<"3.8.0">>}).
+-type http_client() :: module() | {module(), http_client_opts()}.
+
+?DOC("""
+Options passed to the HTTP client implementation.
+
+Standard options:
+* `timeout` - Request timeout in milliseconds
+* `ssl` - SSL/TLS options (see `ssl:tls_option()`)
+
+For the default `oidcc_http_client_httpc`:
+* `httpc_profile` - httpc profile to use (see `httpc:request/5`)
+""").
+?DOC(#{since => <<"3.8.0">>}).
+-type http_client_opts() :: #{
+    timeout => timeout(),
+    ssl => [ssl:tls_option()],
+    httpc_profile => atom() | pid(),
+    atom() => term()
+}.
+
+?DOC("HTTP client error").
+?DOC(#{since => <<"3.8.0">>}).
+-type error() :: term().
+
+?DOC("""
+Perform an HTTP request.
+
+The implementation should:
+1. Execute the HTTP request according to `Request`
+2. Return `{ok, Response}` on success (HTTP 1xx-5xx)
+3. Return `{error, Reason}` on connection/transport errors
+""").
+?DOC(#{since => <<"3.8.0">>}).
+-callback request(Request, Opts) -> {ok, Response} | {error, Error} when
+    Request :: request(),
+    Opts :: http_client_opts(),
+    Response :: response(),
+    Error :: error().

--- a/src/oidcc_http_client_httpc.erl
+++ b/src/oidcc_http_client_httpc.erl
@@ -1,0 +1,86 @@
+-module(oidcc_http_client_httpc).
+
+-feature(maybe_expr, enable).
+
+-behaviour(oidcc_http_client).
+
+-include("internal/doc.hrl").
+?MODULEDOC("""
+Default HTTP client implementation using Erlang's built-in `httpc`.
+
+This is the default HTTP client used by oidcc. It wraps `httpc:request/5` from
+the `inets` application.
+
+## Options
+
+* `timeout` - Request timeout in milliseconds (default: 1 minute)
+* `ssl` - SSL/TLS options (see `ssl:tls_option()`)
+* `httpc_profile` - httpc profile to use (default: `default`)
+
+## Example
+
+```erlang
+oidcc_provider_configuration:load_configuration(Issuer, #{
+    request_opts => #{
+        timeout => 30000,
+        ssl => [{verify, verify_peer}, {cacerts, public_key:cacerts_get()}],
+        httpc_profile => my_profile
+    }
+}).
+```
+""").
+?MODULEDOC(#{since => <<"3.8.0">>}).
+
+-export([request/2]).
+
+?DOC(false).
+-spec request(Request, Opts) -> {ok, Response} | {error, Error} when
+    Request :: oidcc_http_client:request(),
+    Opts :: oidcc_http_client:http_client_opts(),
+    Response :: oidcc_http_client:response(),
+    Error :: oidcc_http_client:error().
+request(Request, Opts) ->
+    #{method := Method, url := Url, headers := Headers} = Request,
+    Body = maps:get(body, Request, <<>>),
+
+    Timeout = maps:get(timeout, Opts, timer:minutes(1)),
+    SslOpts = maps:get(ssl, Opts, undefined),
+    HttpProfile = maps:get(httpc_profile, Opts, default),
+
+    HttpcRequest = build_httpc_request(Method, Url, Headers, Body),
+    HttpOpts = build_http_opts(Timeout, SslOpts),
+
+    case httpc:request(Method, HttpcRequest, HttpOpts, [{body_format, binary}], HttpProfile) of
+        {ok, {{_HttpVersion, Status, _Reason}, RespHeaders, RespBody}} ->
+            {ok, #{
+                status => Status,
+                headers => RespHeaders,
+                body => RespBody
+            }};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec build_httpc_request(Method, Url, Headers, Body) -> HttpcRequest when
+    Method :: head | get | put | patch | post | trace | options | delete,
+    Url :: uri_string:uri_string(),
+    Headers :: [oidcc_http_client:header()],
+    Body :: iodata(),
+    HttpcRequest :: {uri_string:uri_string(), [oidcc_http_client:header()]}
+        | {uri_string:uri_string(), [oidcc_http_client:header()], string(), iodata()}.
+build_httpc_request(Method, Url, Headers, _Body) when
+    Method =:= get; Method =:= head; Method =:= options; Method =:= delete; Method =:= trace
+->
+    {Url, Headers};
+build_httpc_request(_Method, Url, Headers, Body) ->
+    ContentType = proplists:get_value("content-type", Headers, "application/x-www-form-urlencoded"),
+    {Url, Headers, ContentType, Body}.
+
+-spec build_http_opts(Timeout, SslOpts) -> HttpOpts when
+    Timeout :: timeout(),
+    SslOpts :: [ssl:tls_option()] | undefined,
+    HttpOpts :: [{atom(), term()}].
+build_http_opts(Timeout, undefined) ->
+    [{timeout, Timeout}];
+build_http_opts(Timeout, SslOpts) ->
+    [{timeout, Timeout}, {ssl, SslOpts}].

--- a/test/oidcc_http_client_SUITE.erl
+++ b/test/oidcc_http_client_SUITE.erl
@@ -1,0 +1,135 @@
+-module(oidcc_http_client_SUITE).
+
+-export([all/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+-export([custom_http_client_via_request_opts/1]).
+-export([custom_http_client_via_app_config/1]).
+-export([http_client_with_extra_opts/1]).
+-export([default_http_client_backwards_compat/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() ->
+    [
+        custom_http_client_via_request_opts,
+        custom_http_client_via_app_config,
+        http_client_with_extra_opts,
+        default_http_client_backwards_compat
+    ].
+
+init_per_suite(_Config) ->
+    {ok, _} = application:ensure_all_started(oidcc),
+    [].
+
+end_per_suite(_Config) ->
+    ok = application:stop(oidcc).
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    application:unset_env(oidcc, http_client),
+    meck:unload(),
+    ok.
+
+telemetry_opts() ->
+    #{
+        topic => [oidcc, oidcc_http_client_SUITE]
+    }.
+
+custom_http_client_via_request_opts(_Config) ->
+    meck:new(mock_http_client, [non_strict]),
+    meck:expect(mock_http_client, request, fun(Request, _Opts) ->
+        #{method := get, url := "https://example.com/.well-known/openid-configuration"} = Request,
+        {ok, #{
+            status => 200,
+            headers => [{"content-type", "application/json"}],
+            body => <<"{\"issuer\":\"https://example.com\"}">>
+        }}
+    end),
+
+    Result = oidcc_http_util:request(
+        get,
+        {"https://example.com/.well-known/openid-configuration", []},
+        telemetry_opts(),
+        #{http_client => mock_http_client}
+    ),
+
+    ?assertMatch({ok, {{json, #{<<"issuer">> := <<"https://example.com">>}}, _}}, Result),
+    ?assert(meck:validate(mock_http_client)),
+    ok.
+
+custom_http_client_via_app_config(_Config) ->
+    meck:new(mock_http_client, [non_strict]),
+    meck:expect(mock_http_client, request, fun(_Request, _Opts) ->
+        {ok, #{
+            status => 200,
+            headers => [{"content-type", "application/json"}],
+            body => <<"{\"test\":true}">>
+        }}
+    end),
+
+    application:set_env(oidcc, http_client, mock_http_client),
+
+    Result = oidcc_http_util:request(
+        get,
+        {"https://example.com/test", []},
+        telemetry_opts(),
+        #{}
+    ),
+
+    ?assertMatch({ok, {{json, #{<<"test">> := true}}, _}}, Result),
+    ?assert(meck:validate(mock_http_client)),
+    ok.
+
+http_client_with_extra_opts(_Config) ->
+    meck:new(mock_http_client, [non_strict]),
+    meck:expect(mock_http_client, request, fun(_Request, Opts) ->
+        %% Verify that extra opts are passed through
+        #{custom_option := custom_value} = Opts,
+        {ok, #{
+            status => 200,
+            headers => [{"content-type", "application/json"}],
+            body => <<"{\"extra_opts\":\"received\"}">>
+        }}
+    end),
+
+    Result = oidcc_http_util:request(
+        get,
+        {"https://example.com/test", []},
+        telemetry_opts(),
+        #{http_client => {mock_http_client, #{custom_option => custom_value}}}
+    ),
+
+    ?assertMatch({ok, {{json, #{<<"extra_opts">> := <<"received">>}}, _}}, Result),
+    ?assert(meck:validate(mock_http_client)),
+    ok.
+
+default_http_client_backwards_compat(_Config) ->
+    %% Test that default httpc client still works with existing options
+    meck:new(httpc, [unstick, passthrough]),
+    meck:expect(httpc, request, fun(get, {Url, []}, HttpOpts, [{body_format, binary}], default) ->
+        %% Verify standard options are passed
+        {timeout, _} = lists:keyfind(timeout, 1, HttpOpts),
+        case Url of
+            "https://httpbin.org/get" ->
+                {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], <<"{\"ok\":true}">>}};
+            _ ->
+                meck:passthrough([get, {Url, []}, HttpOpts, [{body_format, binary}], default])
+        end
+    end),
+
+    Result = oidcc_http_util:request(
+        get,
+        {"https://httpbin.org/get", []},
+        telemetry_opts(),
+        #{timeout => 5000}
+    ),
+
+    ?assertMatch({ok, {{json, #{<<"ok">> := true}}, _}}, Result),
+    ok.


### PR DESCRIPTION
This PR adds pluggable HTTP client support to allow users to swap Erlang's built-in `httpc` for alternative HTTP clients.

## Problem

`httpc` sends `Content-Length: 0` header for GET requests, which AWS ELB rejects. This causes `Oidcc.ProviderConfiguration.Worker.start_link/1` to fail when connecting to OIDC providers hosted behind it and potentially other load balancers.


```
{:ok, pid} =Oidcc.ProviderConfiguration.Worker.start_link(%{issuer: "https://identity.moneyhub.co.uk/oidc",name: PocketTax.MoneyHubOidccConfigProvider,})
[error] GenServer PocketTax.MoneyHubOidccConfigProvider terminating
** (stop) {:configuration_load_failed, {:http_error, 400, "<html>\r\n<head><title>400 Bad Request</title></head>\r\n<body>\r\n<center><h1>400 Bad Request</h1></center>\r\n</body>\r\n</html>\r\n"}}
Last message: {:continue, :load_configuration}
State: {:state, :undefined, :undefined, "https://identity.moneyhub.co.uk/oidc", %{}, :undefined, :undefined, PocketTax.MoneyHubOidccConfigProvider, 1000, 30000, :stop, :undefined}
** (EXIT from #PID<0.413.0>) shell process exited with reason: {:configuration_load_failed, {:http_error, 400, "<html>\r\n<head><title>400 Bad Request</title></head>\r\n<body>\r\n<center><h1>400 Bad Request</h1></center>\r\n</body>\r\n</html>\r\n"}}

```


## Solution

Introduce an HTTP client behaviour:

- **`oidcc_http_client`** - Erlang behaviour with `request/2` callback
- **`oidcc_http_client_httpc`** - Default adapter wrapping `httpc` (preserves backwards compatibility)
- **`Oidcc.HttpClient.Req`** - Optional Req adapter for Elixir projects (only compiles when `req` is a dependency)

### Configuration

Per-request:
```elixir
Oidcc.ProviderConfiguration.Worker.start_link(%{
  issuer: "https://example.com",
  provider_configuration_opts: %{
    request_opts: %{http_client: Oidcc.HttpClient.Req}
  }
})
```

Application-wide:
```elixir
config :oidcc, http_client: Oidcc.HttpClient.Req
```

## Backwards Compatibility

- Default behaviour unchanged (`httpc`)
- Existing `timeout`, `ssl`, `httpc_profile` options continue to work
- No breaking changes for existing users


