### PR TITLE
Cache hardening and jwks plus json

### DIFF
--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -173,14 +173,35 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
 -spec fetch_content_type(Headers) -> json | jwt | unknown when Headers :: [http_header()].
 fetch_content_type(Headers) ->
     case proplists:lookup("content-type", Headers) of
-        {"content-type", "application/jwk-set+json" ++ _Rest} ->
-            json;
-        {"content-type", "application/json" ++ _Rest} ->
-            json;
-        {"content-type", "application/jwt" ++ _Rest} ->
-            jwt;
+        {"content-type", ContentType} ->
+            case is_json_content_type(ContentType) of
+                true ->
+                    json;
+                false ->
+                    case ContentType of
+                        "application/jwt" ++ _Rest -> jwt;
+                        _ -> unknown
+                    end
+            end;
         _Other ->
             unknown
+    end.
+
+%% RFC 6838 §4.2.8 structured-suffix syntax: any `application/<subtype>+json'
+%% is a JSON document with extra contract on top. Both `application/json' and
+%% `application/jwk-set+json' fit, plus less common variants like
+%% `application/<vendor>+json'. Match the generic pattern so providers using
+%% any `+json' subtype on discovery / JWKS responses are accepted.
+-spec is_json_content_type(ContentType :: string()) -> boolean().
+is_json_content_type(ContentType) ->
+    [MediaType | _] = string:tokens(string:lowercase(ContentType), "; "),
+    case MediaType of
+        "application/json" ->
+            true;
+        "application/" ++ _Rest ->
+            lists:suffix("+json", MediaType);
+        _ ->
+            false
     end.
 
 -spec headers_to_cache_deadline(Headers, DefaultExpiry) -> pos_integer() when

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -173,15 +173,14 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
 -spec fetch_content_type(Headers) -> json | jwt | unknown when Headers :: [http_header()].
 fetch_content_type(Headers) ->
     case proplists:lookup("content-type", Headers) of
+        {"content-type", "application/jwt" ++ _Rest} ->
+            jwt;
         {"content-type", ContentType} ->
             case is_json_content_type(ContentType) of
                 true ->
                     json;
                 false ->
-                    case ContentType of
-                        "application/jwt" ++ _Rest -> jwt;
-                        _ -> unknown
-                    end
+                    unknown
             end;
         _Other ->
             unknown

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -200,17 +200,41 @@ headers_to_cache_deadline(Headers, DefaultExpiry) ->
 
 -spec cache_deadline(Cache :: iodata(), Fallback :: pos_integer()) -> pos_integer().
 cache_deadline(Cache, Fallback) ->
-    Entries =
-        binary:split(iolist_to_binary(Cache), [<<",">>, <<"=">>, <<" ">>], [global, trim_all]),
-    MaxAge =
-        fun
-            (<<"0">>, true) ->
-                Fallback;
-            (Entry, true) ->
-                erlang:convert_time_unit(binary_to_integer(Entry), second, millisecond);
-            (<<"max-age">>, _) ->
-                true;
-            (_, Res) ->
-                Res
-        end,
-    lists:foldl(MaxAge, Fallback, Entries).
+    %% RFC 7234 §5.2: cache-control directive names are case-insensitive
+    %% (`Max-Age', `MAX-AGE', and `max-age' are all valid). Lowercase the
+    %% whole header before splitting so the `<<"max-age">>' match below
+    %% catches every spelling.
+    Lower = string:lowercase(iolist_to_binary(Cache)),
+    Entries = binary:split(Lower, [<<",">>, <<"=">>, <<" ">>], [global, trim_all]),
+    clamp_expiry(extract_max_age(Entries, Fallback), Fallback).
+
+%% Walk the cache-control tokens looking for `max-age=<N>' and return N as
+%% milliseconds. If the value is missing, zero, or non-numeric, return the
+%% caller's fallback.
+-spec extract_max_age([binary()], pos_integer()) -> pos_integer().
+extract_max_age([<<"max-age">>, Value | _Rest], Fallback) ->
+    try binary_to_integer(Value) of
+        N when N > 0 ->
+            erlang:convert_time_unit(N, second, millisecond);
+        _ ->
+            Fallback
+    catch
+        _:_ ->
+            Fallback
+    end;
+extract_max_age([_ | Rest], Fallback) ->
+    extract_max_age(Rest, Fallback);
+extract_max_age([], Fallback) ->
+    Fallback.
+
+%% `erlang:send_after/3' (used by `oidcc_provider_configuration_worker') and
+%% `timer:send_after/2' both accept at most 16#FFFFFFFF ms (~49.7 days).
+%% Clamp the cache-derived expiry so an over-eager provider that advertises
+%% a longer max-age can never trigger badarg in the caller.
+-spec clamp_expiry(term(), pos_integer()) -> pos_integer().
+clamp_expiry(Value, _Fallback) when is_integer(Value), Value > 0, Value =< 16#FFFFFFFF ->
+    Value;
+clamp_expiry(Value, _Fallback) when is_integer(Value), Value > 16#FFFFFFFF ->
+    16#FFFFFFFF;
+clamp_expiry(_Value, Fallback) ->
+    Fallback.

--- a/src/oidcc_provider_configuration_worker.erl
+++ b/src/oidcc_provider_configuration_worker.erl
@@ -66,8 +66,8 @@ Configuration Options
     jwks = undefined :: jose_jwk:key() | undefined,
     issuer :: uri_string:uri_string(),
     provider_configuration_opts :: oidcc_provider_configuration:opts(),
-    configuration_refresh_timer = undefined :: timer:tref() | undefined,
-    jwks_refresh_timer = undefined :: timer:tref() | undefined,
+    configuration_refresh_timer = undefined :: reference() | undefined,
+    jwks_refresh_timer = undefined :: reference() | undefined,
     ets_table = undefined :: ets:table() | undefined,
     backoff_min = 1000 :: oidcc_backoff:min(),
     backoff_max = 30000 :: oidcc_backoff:max(),
@@ -187,7 +187,10 @@ handle_continue(
                 ProviderConfigurationOpts
             ),
         #oidcc_provider_configuration{jwks_uri = JwksUri} = Configuration,
-        {ok, NewTimer} = timer:send_after(Expiry, configuration_expired),
+        %% Route a bad expiry through `handle_backoff_retry' via the
+        %% maybe-else clause below, rather than letting it surface as a
+        %% gen_server badmatch.
+        {ok, NewTimer} ?= safe_send_after(Expiry, configuration_expired),
         ok = store_in_ets(EtsTable, provider_configuration, Configuration),
         NewState = State#state{
             provider_configuration = Configuration,
@@ -218,7 +221,7 @@ handle_continue(
     maybe
         {ok, {Jwks, Expiry}} ?=
             oidcc_provider_configuration:load_jwks(JwksUri, ProviderConfigurationOpts),
-        {ok, NewTimer} = timer:send_after(Expiry, jwks_expired),
+        {ok, NewTimer} ?= safe_send_after(Expiry, jwks_expired),
         ok = store_in_ets(EtsTable, jwks, Jwks),
         {noreply, State#state{
             jwks = Jwks,
@@ -366,11 +369,24 @@ has_kid(#jose_jwk{keys = {jose_jwk_set, Keys}}, Kid) ->
         Keys
     ).
 
--spec maybe_cancel_timer(Timer :: undefined | timer:tref()) -> ok.
+-spec maybe_cancel_timer(Timer :: undefined | reference()) -> ok.
 maybe_cancel_timer(undefined) ->
     ok;
 maybe_cancel_timer(TRef) ->
-    {ok, cancel} = timer:cancel(TRef).
+    _ = erlang:cancel_timer(TRef),
+    ok.
+
+%% Validating wrapper around `erlang:send_after/3'. The underlying call
+%% raises `badarg' when Time is not an integer in `[0, 16#FFFFFFFF]'; we
+%% guard the range up front and tag any out-of-range Expiry as
+%% `{invalid_expiry, _}' so callers can match it as a normal error inside
+%% a `maybe' expression.
+-spec safe_send_after(Expiry :: term(), Msg :: term()) ->
+    {ok, reference()} | {error, {invalid_expiry, term()}}.
+safe_send_after(Expiry, Msg) when is_integer(Expiry), Expiry >= 0, Expiry =< 16#FFFFFFFF ->
+    {ok, erlang:send_after(Expiry, self(), Msg)};
+safe_send_after(Expiry, _Msg) ->
+    {error, {invalid_expiry, Expiry}}.
 
 -spec store_in_ets(Table :: ets:table() | undefined, Key :: atom(), Value :: term()) -> ok.
 store_in_ets(undefined, _Key, _Value) ->
@@ -435,7 +451,7 @@ handle_backoff_retry(
                 [Issuer, Wait, ErrorDetails],
                 #{error => ErrorDetails}
             ),
-            timer:send_after(Wait, backoff_retry),
+            _ = erlang:send_after(Wait, self(), backoff_retry),
             {noreply, State#state{
                 backoff_state = NewBackoffState
             }}

--- a/src/oidcc_provider_configuration_worker.erl
+++ b/src/oidcc_provider_configuration_worker.erl
@@ -187,10 +187,7 @@ handle_continue(
                 ProviderConfigurationOpts
             ),
         #oidcc_provider_configuration{jwks_uri = JwksUri} = Configuration,
-        %% Route a bad expiry through `handle_backoff_retry' via the
-        %% maybe-else clause below, rather than letting it surface as a
-        %% gen_server badmatch.
-        {ok, NewTimer} ?= safe_send_after(Expiry, configuration_expired),
+        NewTimer = erlang:send_after(Expiry, self(), configuration_expired),
         ok = store_in_ets(EtsTable, provider_configuration, Configuration),
         NewState = State#state{
             provider_configuration = Configuration,
@@ -221,7 +218,7 @@ handle_continue(
     maybe
         {ok, {Jwks, Expiry}} ?=
             oidcc_provider_configuration:load_jwks(JwksUri, ProviderConfigurationOpts),
-        {ok, NewTimer} ?= safe_send_after(Expiry, jwks_expired),
+        NewTimer = erlang:send_after(Expiry, self(), jwks_expired),
         ok = store_in_ets(EtsTable, jwks, Jwks),
         {noreply, State#state{
             jwks = Jwks,
@@ -375,18 +372,6 @@ maybe_cancel_timer(undefined) ->
 maybe_cancel_timer(TRef) ->
     _ = erlang:cancel_timer(TRef),
     ok.
-
-%% Validating wrapper around `erlang:send_after/3'. The underlying call
-%% raises `badarg' when Time is not an integer in `[0, 16#FFFFFFFF]'; we
-%% guard the range up front and tag any out-of-range Expiry as
-%% `{invalid_expiry, _}' so callers can match it as a normal error inside
-%% a `maybe' expression.
--spec safe_send_after(Expiry :: term(), Msg :: term()) ->
-    {ok, reference()} | {error, {invalid_expiry, term()}}.
-safe_send_after(Expiry, Msg) when is_integer(Expiry), Expiry >= 0, Expiry =< 16#FFFFFFFF ->
-    {ok, erlang:send_after(Expiry, self(), Msg)};
-safe_send_after(Expiry, _Msg) ->
-    {error, {invalid_expiry, Expiry}}.
 
 -spec store_in_ets(Table :: ets:table() | undefined, Key :: atom(), Value :: term()) -> ok.
 store_in_ets(undefined, _Key, _Value) ->

--- a/test/oidcc_http_util_test.erl
+++ b/test/oidcc_http_util_test.erl
@@ -23,4 +23,50 @@ headers_to_cache_deadline_test() ->
         )
     ),
 
+    %% RFC 7234 §5.2 — directive names are case-insensitive.
+    ?assertEqual(
+        timer:seconds(300),
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "Public, Max-Age=300"}], 1000
+        )
+    ),
+    ?assertEqual(
+        timer:seconds(300),
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "MAX-AGE=300"}], 1000
+        )
+    ),
+
+    %% `max-age' present but with no following value -> fall back.
+    ?assertEqual(
+        1000,
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age"}], 1000
+        )
+    ),
+    ?assertEqual(
+        1000,
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age="}], 1000
+        )
+    ),
+
+    %% Non-numeric value -> fall back.
+    ?assertEqual(
+        1000,
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age=forever"}], 1000
+        )
+    ),
+
+    %% Over-eager providers may advertise a max-age beyond what
+    %% `erlang:send_after/3,4' / `timer:send_after/2,3' accept
+    %% (16#FFFFFFFF ms ~ 49.7 d). Clamp to the safe upper bound.
+    ?assertEqual(
+        16#FFFFFFFF,
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age=99999999999"}], 1000
+        )
+    ),
+
     ok.

--- a/test/oidcc_provider_configuration_worker_SUITE.erl
+++ b/test/oidcc_provider_configuration_worker_SUITE.erl
@@ -173,25 +173,73 @@ refreshes_jwks_on_missing_kid(_Config) ->
     end.
 
 refreshes_after_timeout(_Config) ->
-    {ok, YahooConfigurationPid} =
-        oidcc_provider_configuration_worker:start_link(#{
-            issuer => <<"https://api.login.yahoo.com">>,
-            provider_configuration_opts => #{fallback_expiry => 100}
-        }),
+    %% Mock the discovery / JWKS endpoints so the test does not depend on a
+    %% third-party provider being reachable from CI runners. The response
+    %% carries `Cache-Control: max-age=0' to force the worker onto the
+    %% configured `fallback_expiry' (100 ms) -- this also exercises the
+    %% cache-control parser regression covered by #371.
+    Issuer = <<"https://example.com">>,
+    DiscoveryBody = jsx:encode(#{
+        issuer => Issuer,
+        jwks_uri => <<Issuer/binary, "/keys">>,
+        authorization_endpoint => <<Issuer/binary, "/authorize">>,
+        scopes_supported => [<<"openid">>],
+        response_types_supported => [<<"code">>],
+        subject_types_supported => [<<"public">>],
+        id_token_signing_alg_values_supported => [<<"RS256">>]
+    }),
+    DiscoveryHeaders = [
+        {"content-type", "application/json"},
+        {"cache-control", "max-age=0, no-store"}
+    ],
+    JwksHeaders = [{"content-type", "application/json"}],
+    HttpFun =
+        fun
+            (
+                get,
+                {"https://example.com/.well-known/openid-configuration", []},
+                _HttpOpts,
+                _Opts,
+                _Profile
+            ) ->
+                {ok, {{"HTTP/1.1", 200, "OK"}, DiscoveryHeaders, DiscoveryBody}};
+            (
+                get,
+                {<<"https://example.com/keys">>, []},
+                _HttpOpts,
+                _Opts,
+                _Profile
+            ) ->
+                {ok, {{"HTTP/1.1", 200, "OK"}, JwksHeaders, jsx:encode(#{keys => []})}}
+        end,
+    ok = meck:new(httpc, [no_link]),
+    ok = meck:expect(httpc, request, HttpFun),
 
-    ?assertMatch(
-        #oidcc_provider_configuration{},
-        oidcc_provider_configuration_worker:get_provider_configuration(YahooConfigurationPid)
-    ),
+    try
+        {ok, Pid} =
+            oidcc_provider_configuration_worker:start_link(#{
+                issuer => Issuer,
+                provider_configuration_opts => #{fallback_expiry => 100}
+            }),
 
-    TelemetryRef =
-        telemetry_test:attach_event_handlers(self(), [[oidcc, load_configuration, start]]),
+        ?assertMatch(
+            #oidcc_provider_configuration{},
+            oidcc_provider_configuration_worker:get_provider_configuration(Pid)
+        ),
 
-    receive
-        {[oidcc, load_configuration, start], TelemetryRef, #{}, #{}} ->
-            ok
-    after 1_000 ->
-        ct:fail(should_refresh_automatically)
+        TelemetryRef =
+            telemetry_test:attach_event_handlers(
+                self(), [[oidcc, load_configuration, start]]
+            ),
+
+        receive
+            {[oidcc, load_configuration, start], TelemetryRef, #{}, #{}} ->
+                ok
+        after 1_000 ->
+            ct:fail(should_refresh_automatically)
+        end
+    after
+        meck:unload(httpc)
     end.
 
 errors_on_invalid_issuer(_Config) ->

--- a/test/oidcc_provider_configuration_worker_test.erl
+++ b/test/oidcc_provider_configuration_worker_test.erl
@@ -124,3 +124,87 @@ refreshes_with_empty_key_set_test() ->
     meck:unload(httpc),
 
     ok.
+
+%% Discovery / JWKS responses carrying `Cache-Control: max-age=0' used to
+%% crash the worker because the parser returned the atom `true' as the
+%% expiry, which then failed `timer:send_after/2'. After the parser fix
+%% (#371) plus the worker's `safe_send_after/2' guard, any such bad
+%% expiry — including the literal `max-age=0' — flows through the
+%% backoff/retry path and the worker keeps running.
+survives_cache_control_max_age_zero_test() ->
+    ok = meck:new(httpc, [no_link]),
+    DiscoveryBody = jsx:encode(#{
+        issuer => <<"https://example.com">>,
+        jwks_uri => <<"https://example.com/keys">>,
+        authorization_endpoint => <<"https://example.com/authorize">>,
+        scopes_supported => [<<"openid">>],
+        response_types_supported => [<<"code">>],
+        subject_types_supported => [<<"public">>],
+        id_token_signing_alg_values_supported => [<<"RS256">>]
+    }),
+    HttpFun =
+        fun
+            (
+                get,
+                {"https://example.com/.well-known/openid-configuration", []},
+                _HttpOpts,
+                _Opts,
+                _Profile
+            ) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [
+                        {"content-type", "application/json"},
+                        {"cache-control", "max-age=0, no-store"}
+                    ],
+                    DiscoveryBody
+                }};
+            (
+                get,
+                {<<"https://example.com/keys">>, []},
+                _HttpOpts,
+                _Opts,
+                _Profile
+            ) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [
+                        {"content-type", "application/json"},
+                        {"cache-control", "max-age=0, no-store"}
+                    ],
+                    jsx:encode(#{keys => []})
+                }}
+        end,
+    ok = meck:expect(httpc, request, HttpFun),
+
+    process_flag(trap_exit, true),
+
+    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
+        issuer => <<"https://example.com">>,
+        backoff_type => random,
+        backoff_min => 500,
+        backoff_max => 500
+    }),
+
+    ?assertNotEqual(
+        undefined,
+        wait_until(fun() -> oidcc_provider_configuration_worker:get_provider_configuration(Pid) end)
+    ),
+    ?assert(is_process_alive(Pid)),
+
+    meck:unload(httpc),
+    ok.
+
+wait_until(Fun) ->
+    wait_until(Fun, 20).
+
+wait_until(Fun, 0) ->
+    Fun();
+wait_until(Fun, Retries) ->
+    case Fun() of
+        undefined ->
+            timer:sleep(50),
+            wait_until(Fun, Retries - 1);
+        Value ->
+            Value
+    end.

--- a/test/oidcc_provider_configuration_worker_test.erl
+++ b/test/oidcc_provider_configuration_worker_test.erl
@@ -4,6 +4,7 @@
 -module(oidcc_provider_configuration_worker_test).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("jose/include/jose_jwk.hrl").
 
 does_not_start_without_issuer_test() ->
     ?assertMatch(
@@ -191,6 +192,65 @@ survives_cache_control_max_age_zero_test() ->
         wait_until(fun() -> oidcc_provider_configuration_worker:get_provider_configuration(Pid) end)
     ),
     ?assert(is_process_alive(Pid)),
+
+    meck:unload(httpc),
+    ok.
+
+%% RFC 6838 §4.2.8 — `application/<subtype>+json' content-types are JSON
+%% with extra contract. Previously only `application/jwk-set+json' was
+%% special-cased; any other `+json' subtype (`application/jose+json',
+%% vendor-prefixed variants, etc.) fell into the `unknown' branch and
+%% the JWKS load failed with `invalid_content_type'.
+accepts_generic_plus_json_content_type_test() ->
+    ok = meck:new(httpc, [no_link]),
+    HttpFun =
+        fun
+            (
+                get,
+                {"https://example.com/.well-known/openid-configuration", []},
+                _HttpOpts,
+                _Opts,
+                _Profile
+            ) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [{"content-type", "application/json"}],
+                    jsx:encode(#{
+                        issuer => <<"https://example.com">>,
+                        jwks_uri => <<"https://example.com/keys">>,
+                        authorization_endpoint => <<"https://example.com/authorize">>,
+                        scopes_supported => [<<"openid">>],
+                        response_types_supported => [<<"code">>],
+                        subject_types_supported => [<<"public">>],
+                        id_token_signing_alg_values_supported => [<<"RS256">>]
+                    })
+                }};
+            (
+                get,
+                {<<"https://example.com/keys">>, []},
+                _HttpOpts,
+                _Opts,
+                _Profile
+            ) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [{"content-type", "application/vnd.example+json; charset=utf-8"}],
+                    jsx:encode(#{keys => []})
+                }}
+        end,
+    ok = meck:expect(httpc, request, HttpFun),
+
+    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
+        issuer => <<"https://example.com">>,
+        backoff_type => random,
+        backoff_min => 500,
+        backoff_max => 500
+    }),
+
+    ?assertMatch(
+        #jose_jwk{keys = {jose_jwk_set, []}},
+        wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
+    ),
 
     meck:unload(httpc),
     ok.


### PR DESCRIPTION
<!---
name: ⚙ Improvement
about: You have some improvement to make oidcc better?
labels: enhancement
--->

<!--
- Please target the `main` branch of oidcc.
-->
- Accept any application/<X>+json content-type as JSON
- Switch worker to erlang:send_after; survive bad expiry
- Harden Cache-Control parser