### PR TITLE
Add pluggable HTTP adapters

### DIFF
--- a/src/oidcc_authorization.erl
+++ b/src/oidcc_authorization.erl
@@ -36,6 +36,7 @@ See https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest.
 * `redirect_uri` - redirect target after authorization is completed
 * `url_extension` - add custom query parameters to the authorization URL
 * `response_mode` - response mode to use (defaults to `<<"query">>`)
+* `request_opts` - config for the pushed authorization HTTP request
 """).
 ?MODULEDOC(#{since => <<"3.0.0">>}).
 -type opts() ::
@@ -49,7 +50,8 @@ See https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest.
         require_purpose => boolean(),
         redirect_uri => uri_string:uri_string(),
         url_extension => oidcc_http_util:query_params(),
-        response_mode => binary()
+        response_mode => binary(),
+        request_opts => oidcc_http_util:request_opts()
     }.
 
 ?MODULEDOC(#{since => <<"3.0.0">>}).

--- a/src/oidcc_http_adapter.erl
+++ b/src/oidcc_http_adapter.erl
@@ -1,0 +1,199 @@
+%% SPDX-FileCopyrightText: 2023 Erlang Ecosystem Foundation
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(oidcc_http_adapter).
+
+-hank([{unused_callbacks, [{request, 5}]}]).
+
+-include("internal/doc.hrl").
+?MODULEDOC("""
+HTTP transport adapter.
+
+Adapters perform the transport operation for `oidcc_http_util` and return the
+raw response representation used by `httpc:request/5`. OIDCC remains
+responsible for telemetry, response decoding, content-type validation, DPoP
+nonce handling, and error normalization.
+
+Configure an adapter through the `request_opts` for each outbound operation:
+
+```erlang
+Adapter = {my_http_adapter, #{}},
+
+{ok, ProviderPid} =
+  oidcc_provider_configuration_worker:start_link(#{
+    issuer => <<"https://my.provider">>,
+    provider_configuration_opts => #{
+      request_opts => #{
+        http_adapter => Adapter
+      }
+    }
+  }),
+
+{ok, ClientContext} =
+  oidcc_client_context:from_configuration_worker(
+    ProviderPid,
+    <<"client_id">>,
+    <<"client_secret">>
+  ),
+
+oidcc_token:retrieve(
+  AuthCode,
+  ClientContext,
+  #{
+    request_opts => #{
+      http_adapter => Adapter
+    }
+  }
+).
+```
+
+Elixir modules can implement the same behavior:
+
+```elixir
+defmodule MyHttpAdapter do
+  @behaviour :oidcc_http_adapter
+
+  @impl true
+  def request(method, request, http_options, request_options, config) do
+    # Return {:ok, {{http_version, status, reason}, headers, binary_body}}
+    # or {:error, reason}.
+  end
+end
+
+adapter = {MyHttpAdapter, %{}}
+
+{:ok, provider_pid} =
+  Oidcc.ProviderConfiguration.Worker.start_link(%{
+    issuer: "https://my.provider",
+    provider_configuration_opts: %{
+      request_opts: %{
+        http_adapter: adapter
+      }
+    }
+  })
+
+{:ok, client_context} =
+  Oidcc.ClientContext.from_configuration_worker(
+    provider_pid,
+    "client_id",
+    "client_secret"
+  )
+
+Oidcc.Token.retrieve(auth_code, client_context, %{
+  request_opts: %{
+    http_adapter: adapter
+  }
+})
+```
+
+The provider worker's `provider_configuration_opts.request_opts` apply only to
+provider discovery and JWKS requests. They are not copied into token, userinfo,
+introspection, registration, or authorization options. Configure
+`request_opts.http_adapter` for both paths when both need the adapter.
+
+The complete request tuple, including its original URL, is passed to the
+adapter unchanged. An adapter must return:
+
+* the raw status-line tuple `{HttpVersion, Status, Reason}`;
+* headers in the representation expected by `oidcc_http_util`;
+* a binary response body; or
+* `{error, Reason}` for a transport failure.
+
+Response header names must be lower-case byte strings as returned by `httpc`.
+Header values may be any iodata accepted by `httpc`.
+
+Adapters control redirect handling and response-body collection. Security-aware
+adapters must not follow redirects implicitly. They must resolve and validate
+each redirect destination before connecting, and enforce response-size limits
+while receiving the body.
+
+Adapters may emit their own telemetry. The telemetry span owned by
+`oidcc_http_util` remains authoritative for OIDCC HTTP operations.
+""").
+
+-export_type([config/0]).
+-export_type([http_header/0]).
+-export_type([http_options/0]).
+-export_type([method/0]).
+-export_type([request/0]).
+-export_type([request_body/0]).
+-export_type([request_options/0]).
+-export_type([response/0]).
+-export_type([response_header/0]).
+
+?DOC("Adapter module and adapter-specific configuration.").
+-type config() :: {module(), map()}.
+
+?DOC("HTTP method accepted by `httpc:request/5`.").
+-type method() :: head | get | put | patch | post | trace | options | delete.
+
+?DOC("HTTP request header representation accepted by `httpc:request/5`.").
+-type http_header() :: {Field :: [byte()] | binary(), Value :: iodata()}.
+
+?DOC("HTTP response header representation returned by `httpc:request/5`.").
+-type response_header() :: {Field :: [byte()], Value :: iodata()}.
+
+?DOC("HTTP request tuple accepted by `httpc:request/5`.").
+-type request() ::
+    {uri_string:uri_string(), [http_header()]}
+    | {
+        uri_string:uri_string(),
+        [http_header()],
+        ContentType :: uri_string:uri_string(),
+        request_body()
+    }.
+
+?DOC("HTTP request body accepted by `httpc:request/5`.").
+-type request_body() ::
+    iolist()
+    | binary()
+    | {
+        fun((Accumulator :: term()) -> eof | {ok, iolist(), Accumulator :: term()}),
+        Accumulator :: term()
+    }
+    | {
+        chunkify,
+        fun((Accumulator :: term()) -> eof | {ok, iolist(), Accumulator :: term()}),
+        Accumulator :: term()
+    }.
+
+?DOC("""
+HTTP options constructed by `oidcc_http_util`.
+
+The list includes the request timeout and, when configured, TLS options.
+""").
+-type http_options() :: [
+    {timeout, timeout()} | {ssl, [ssl:tls_option()]}
+].
+
+?DOC("Request options passed to adapters.").
+-type request_options() :: [{body_format, binary}].
+
+?DOC("Raw `httpc`-compatible response.").
+-type response() ::
+    {ok, {
+        {
+            HttpVersion :: string(),
+            Status :: non_neg_integer(),
+            Reason :: string()
+        },
+        [response_header()],
+        binary()
+    }}
+    | {error, term()}.
+
+?DOC("""
+Perform an HTTP request.
+
+`Request` contains the original URL and is passed without transformation.
+`HttpOptions` and `RequestOptions` are the values constructed by
+`oidcc_http_util`. `AdapterConfig` is the map paired with the adapter module in
+`request_opts.http_adapter`.
+""").
+-callback request(
+    Method :: method(),
+    Request :: request(),
+    HttpOptions :: http_options(),
+    RequestOptions :: request_options(),
+    AdapterConfig :: map()
+) -> response().

--- a/src/oidcc_http_adapter.erl
+++ b/src/oidcc_http_adapter.erl
@@ -112,14 +112,13 @@ Adapters may emit their own telemetry. The telemetry span owned by
 """).
 
 -export_type([config/0]).
--export_type([http_header/0]).
+-export_type([header/0]).
 -export_type([http_options/0]).
 -export_type([method/0]).
 -export_type([request/0]).
 -export_type([request_body/0]).
 -export_type([request_options/0]).
 -export_type([response/0]).
--export_type([response_header/0]).
 
 ?DOC("Adapter module and adapter-specific configuration.").
 -type config() :: {module(), map()}.
@@ -127,18 +126,15 @@ Adapters may emit their own telemetry. The telemetry span owned by
 ?DOC("HTTP method accepted by `httpc:request/5`.").
 -type method() :: head | get | put | patch | post | trace | options | delete.
 
-?DOC("HTTP request header representation accepted by `httpc:request/5`.").
--type http_header() :: {Field :: [byte()], Value :: iodata()}.
-
-?DOC("HTTP response header representation returned by `httpc:request/5`.").
--type response_header() :: {Field :: [byte()], Value :: iodata()}.
+?DOC("HTTP header representation accepted and returned by `httpc:request/5`.").
+-type header() :: {Field :: [byte()], Value :: binary() | iolist()}.
 
 ?DOC("HTTP request tuple accepted by `httpc:request/5`.").
 -type request() ::
-    {uri_string:uri_string(), [http_header()]}
+    {uri_string:uri_string(), [header()]}
     | {
         uri_string:uri_string(),
-        [http_header()],
+        [header()],
         ContentType :: string(),
         request_body()
     }.
@@ -177,7 +173,7 @@ The list includes the request timeout and, when configured, TLS options.
             Status :: non_neg_integer(),
             Reason :: string()
         },
-        [response_header()],
+        [header()],
         binary()
     }}
     | {error, term()}.

--- a/src/oidcc_http_adapter.erl
+++ b/src/oidcc_http_adapter.erl
@@ -128,7 +128,7 @@ Adapters may emit their own telemetry. The telemetry span owned by
 -type method() :: head | get | put | patch | post | trace | options | delete.
 
 ?DOC("HTTP request header representation accepted by `httpc:request/5`.").
--type http_header() :: {Field :: [byte()] | binary(), Value :: iodata()}.
+-type http_header() :: {Field :: [byte()], Value :: iodata()}.
 
 ?DOC("HTTP response header representation returned by `httpc:request/5`.").
 -type response_header() :: {Field :: [byte()], Value :: iodata()}.
@@ -139,7 +139,7 @@ Adapters may emit their own telemetry. The telemetry span owned by
     | {
         uri_string:uri_string(),
         [http_header()],
-        ContentType :: uri_string:uri_string(),
+        ContentType :: string(),
         request_body()
     }.
 

--- a/src/oidcc_http_adapter_httpc.erl
+++ b/src/oidcc_http_adapter_httpc.erl
@@ -1,0 +1,24 @@
+%% SPDX-FileCopyrightText: 2023 Erlang Ecosystem Foundation
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(oidcc_http_adapter_httpc).
+
+-include("internal/doc.hrl").
+?MODULEDOC("HTTP Client Adapter").
+
+-behaviour(oidcc_http_adapter).
+
+-export([request/5]).
+
+?DOC(false).
+-spec request(Method, Request, HttpOptions, RequestOptions, AdapterConfig) ->
+    oidcc_http_adapter:response()
+when
+    Method :: oidcc_http_adapter:method(),
+    Request :: oidcc_http_adapter:request(),
+    HttpOptions :: oidcc_http_adapter:http_options(),
+    RequestOptions :: oidcc_http_adapter:request_options(),
+    AdapterConfig :: #{profile => atom() | pid()}.
+request(Method, Request, HttpOptions, RequestOptions, AdapterConfig) ->
+    Profile = maps:get(profile, AdapterConfig, default),
+    httpc:request(Method, Request, HttpOptions, RequestOptions, Profile).

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -21,9 +21,9 @@
 ?DOC(#{since => <<"3.0.0">>}).
 -type query_params() :: [{unicode:chardata(), unicode:chardata() | true}].
 
-?DOC("See `t:oidcc_http_adapter:http_header/0`.").
+?DOC("HTTP header representation used by OIDCC.").
 ?DOC(#{since => <<"3.0.0">>}).
--type http_header() :: oidcc_http_adapter:http_header().
+-type http_header() :: {Field :: [byte()] | binary(), Value :: iodata()}.
 
 ?DOC(#{since => <<"3.0.0">>}).
 -type error() ::

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -21,18 +21,18 @@
 ?DOC(#{since => <<"3.0.0">>}).
 -type query_params() :: [{unicode:chardata(), unicode:chardata() | true}].
 
-?DOC("See `httpc:request/5`.").
+?DOC("See `t:oidcc_http_adapter:http_header/0`.").
 ?DOC(#{since => <<"3.0.0">>}).
--type http_header() :: {Field :: [byte()] | binary(), Value :: iodata()}.
+-type http_header() :: oidcc_http_adapter:http_header().
 
 ?DOC(#{since => <<"3.0.0">>}).
 -type error() ::
-    {http_error, StatusCode :: pos_integer(), HttpBodyResult :: binary() | map()}
+    {http_error, StatusCode :: non_neg_integer(), HttpBodyResult :: binary() | map()}
     | {use_dpop_nonce, Nonce :: binary(), HttpBodyResult :: binary() | map()}
     | invalid_content_type
     | httpc_error().
 
-?DOC("See `httpc:request/5` for additional errors.").
+?DOC("Transport error. The default adapter returns errors documented by `httpc:request/5`.").
 ?DOC(#{since => <<"3.0.0">>}).
 -type httpc_error() :: term().
 
@@ -43,12 +43,15 @@ See `httpc:request/5`.
 
 * `timeout` - timeout for request
 * `ssl` - TLS config
+* `httpc_profile` - `httpc` profile used by the default adapter
+* `http_adapter` - `{AdapterModule, AdapterConfigMap}` transport adapter
 """).
 ?DOC(#{since => <<"3.0.0">>}).
 -type request_opts() :: #{
     timeout => timeout(),
     ssl => [ssl:tls_option()],
-    httpc_profile => atom() | pid()
+    httpc_profile => atom() | pid(),
+    http_adapter => oidcc_http_adapter:config()
 }.
 
 ?DOC(#{since => <<"3.0.0">>}).
@@ -75,27 +78,11 @@ bearer_auth_header(Token) ->
 
 ?DOC(false).
 -spec request(Method, Request, TelemetryOpts, RequestOpts) ->
-    {ok, {{json, term()} | {jwt, binary()}, [http_header()]}}
+    {ok, {{json, term()} | {jwt, binary()}, [oidcc_http_adapter:response_header()]}}
     | {error, error()}
 when
-    Method :: head | get | put | patch | post | trace | options | delete,
-    Request ::
-        {uri_string:uri_string(), [http_header()]}
-        | {
-            uri_string:uri_string(),
-            [http_header()],
-            ContentType :: uri_string:uri_string(),
-            HttpBody
-        },
-    HttpBody ::
-        iolist()
-        | binary()
-        | {
-            fun((Accumulator :: term()) -> eof | {ok, iolist(), Accumulator :: term()}),
-            Accumulator :: term()
-        }
-        | {chunkify, fun((Accumulator :: term()) -> eof | {ok, iolist(), Accumulator :: term()}),
-            Accumulator :: term()},
+    Method :: oidcc_http_adapter:method(),
+    Request :: oidcc_http_adapter:request(),
     TelemetryOpts :: telemetry_opts(),
     RequestOpts :: request_opts().
 request(Method, Request, TelemetryOpts, RequestOpts) ->
@@ -104,6 +91,11 @@ request(Method, Request, TelemetryOpts, RequestOpts) ->
     Timeout = maps:get(timeout, RequestOpts, timer:minutes(1)),
     SslOpts = maps:get(ssl, RequestOpts, undefined),
     HttpProfile = maps:get(httpc_profile, RequestOpts, default),
+    {Adapter, AdapterConfig} = maps:get(
+        http_adapter,
+        RequestOpts,
+        {oidcc_http_adapter_httpc, #{profile => HttpProfile}}
+    ),
 
     HttpOpts0 = [{timeout, Timeout}],
     HttpOpts =
@@ -118,12 +110,16 @@ request(Method, Request, TelemetryOpts, RequestOpts) ->
         fun() ->
             maybe
                 {ok, {_StatusLine, Headers, _Result} = Response} ?=
-                    httpc:request(
-                        Method,
-                        Request,
-                        HttpOpts,
-                        [{body_format, binary}],
-                        HttpProfile
+                    erlang:apply(
+                        Adapter,
+                        request,
+                        [
+                            Method,
+                            Request,
+                            HttpOpts,
+                            [{body_format, binary}],
+                            AdapterConfig
+                        ]
                     ),
                 {ok, BodyAndFormat} ?= extract_successful_response(Response),
                 {{ok, {BodyAndFormat, Headers}}, TelemetryExtraMeta}
@@ -138,9 +134,9 @@ request(Method, Request, TelemetryOpts, RequestOpts) ->
     {ok, {json, term()} | {jwt, binary()}} | {error, error()}
 when
     StatusLine :: {HttpVersion, StatusCode, string()},
-    HttpVersion :: uri_string:uri_string(),
-    StatusCode :: pos_integer(),
-    HttpHeader :: http_header(),
+    HttpVersion :: string(),
+    StatusCode :: non_neg_integer(),
+    HttpHeader :: oidcc_http_adapter:response_header(),
     HttpBodyResult :: binary().
 extract_successful_response({{_HttpVersion, Status, _HttpStatusName}, Headers, HttpBodyResult}) when
     Status == 200 orelse Status == 201
@@ -170,17 +166,21 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
             {error, {http_error, StatusCode, Body}}
     end.
 
--spec fetch_content_type(Headers) -> json | jwt | unknown when Headers :: [http_header()].
+-spec fetch_content_type(Headers) -> json | jwt | unknown when
+    Headers :: [oidcc_http_adapter:response_header()].
 fetch_content_type(Headers) ->
     case proplists:lookup("content-type", Headers) of
-        {"content-type", "application/jwt" ++ _Rest} ->
-            jwt;
         {"content-type", ContentType} ->
-            case is_json_content_type(ContentType) of
-                true ->
-                    json;
-                false ->
-                    unknown
+            case binary:split(iolist_to_binary(ContentType), <<";">>) of
+                [<<"application/jwt">> | _Rest] ->
+                    jwt;
+                [MediaType | _Rest] ->
+                    case is_json_content_type(MediaType) of
+                        true ->
+                            json;
+                        false ->
+                            unknown
+                    end
             end;
         _Other ->
             unknown
@@ -191,20 +191,21 @@ fetch_content_type(Headers) ->
 %% `application/jwk-set+json' fit, plus less common variants like
 %% `application/<vendor>+json'. Match the generic pattern so providers using
 %% any `+json' subtype on discovery / JWKS responses are accepted.
--spec is_json_content_type(ContentType :: string()) -> boolean().
+-spec is_json_content_type(ContentType :: binary()) -> boolean().
 is_json_content_type(ContentType) ->
-    [MediaType | _] = string:tokens(string:lowercase(ContentType), "; "),
+    MediaType = string:lowercase(string:trim(ContentType)),
     case MediaType of
-        "application/json" ->
+        <<"application/json">> ->
             true;
-        "application/" ++ _Rest ->
-            lists:suffix("+json", MediaType);
+        <<"application/", Subtype/binary>> ->
+            Size = byte_size(Subtype),
+            Size >= 5 andalso binary:part(Subtype, Size - 5, 5) =:= <<"+json">>;
         _ ->
             false
     end.
 
 -spec headers_to_cache_deadline(Headers, DefaultExpiry) -> pos_integer() when
-    Headers :: [{Header :: binary(), Value :: binary()}], DefaultExpiry :: non_neg_integer().
+    Headers :: [oidcc_http_adapter:response_header()], DefaultExpiry :: non_neg_integer().
 headers_to_cache_deadline(Headers, DefaultExpiry) ->
     case proplists:lookup("cache-control", Headers) of
         {"cache-control", Cache} ->

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -78,7 +78,7 @@ bearer_auth_header(Token) ->
 
 ?DOC(false).
 -spec request(Method, Request, TelemetryOpts, RequestOpts) ->
-    {ok, {{json, term()} | {jwt, binary()}, [oidcc_http_adapter:response_header()]}}
+    {ok, {{json, term()} | {jwt, binary()}, [oidcc_http_adapter:header()]}}
     | {error, error()}
 when
     Method :: oidcc_http_adapter:method(),
@@ -136,7 +136,7 @@ when
     StatusLine :: {HttpVersion, StatusCode, string()},
     HttpVersion :: string(),
     StatusCode :: non_neg_integer(),
-    HttpHeader :: oidcc_http_adapter:response_header(),
+    HttpHeader :: oidcc_http_adapter:header(),
     HttpBodyResult :: binary().
 extract_successful_response({{_HttpVersion, Status, _HttpStatusName}, Headers, HttpBodyResult}) when
     Status == 200 orelse Status == 201
@@ -167,7 +167,7 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
     end.
 
 -spec fetch_content_type(Headers) -> json | jwt | unknown when
-    Headers :: [oidcc_http_adapter:response_header()].
+    Headers :: [oidcc_http_adapter:header()].
 fetch_content_type(Headers) ->
     case proplists:lookup("content-type", Headers) of
         {"content-type", ContentType} ->
@@ -205,7 +205,7 @@ is_json_content_type(ContentType) ->
     end.
 
 -spec headers_to_cache_deadline(Headers, DefaultExpiry) -> pos_integer() when
-    Headers :: [oidcc_http_adapter:response_header()], DefaultExpiry :: non_neg_integer().
+    Headers :: [oidcc_http_adapter:header()], DefaultExpiry :: non_neg_integer().
 headers_to_cache_deadline(Headers, DefaultExpiry) ->
     case proplists:lookup("cache-control", Headers) of
         {"cache-control", Cache} ->

--- a/src/oidcc_userinfo.erl
+++ b/src/oidcc_userinfo.erl
@@ -37,7 +37,8 @@ See [`Oidcc.Userinfo`](`m:'Elixir.Oidcc.Userinfo'`).
 -type retrieve_opts_no_sub() ::
     #{
         refresh_jwks => oidcc_jwt_util:refresh_jwks_for_unknown_kid_fun(),
-        dpop_nonce => binary()
+        dpop_nonce => binary(),
+        request_opts => oidcc_http_util:request_opts()
     }.
 
 ?DOC("""
@@ -53,13 +54,15 @@ See https://openid.net/specs/openid-connect-core-1_0.html#UserInfoRequest
   (`sub` from id token)
 * `dpop_nonce` - if using DPoP, the `nonce` value to use in the
     proof claim
+* `request_opts` - config for userinfo and distributed-claim HTTP requests
 """).
 ?DOC(#{since => <<"3.0.0">>}).
 -type retrieve_opts() ::
     #{
         refresh_jwks => oidcc_jwt_util:refresh_jwks_for_unknown_kid_fun(),
         expected_subject => binary() | any,
-        dpop_nonce => binary()
+        dpop_nonce => binary(),
+        request_opts => oidcc_http_util:request_opts()
     }.
 
 ?DOC(#{since => <<"3.0.0">>}).

--- a/test/oidcc/http_adapter_test.exs
+++ b/test/oidcc/http_adapter_test.exs
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2023 Erlang Ecosystem Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Oidcc.HttpAdapterTest.Adapter do
+  @behaviour :oidcc_http_adapter
+
+  @impl true
+  def request(method, request, http_options, request_options, config) do
+    send(config.test_pid, {
+      :adapter_request,
+      method,
+      request,
+      http_options,
+      request_options,
+      config
+    })
+
+    {:ok,
+     {{~c"HTTP/1.1", 200, ~c"OK"}, [{~c"content-type", ~c"application/json"}],
+      ~s({"language":"elixir"})}}
+  end
+end
+
+defmodule Oidcc.HttpAdapterTest do
+  use ExUnit.Case, async: true
+
+  test "an Elixir module can implement and be passed as the Erlang adapter behavior" do
+    request = {"https://example.com", [{"accept", "application/json"}]}
+    config = %{test_pid: self(), custom: %{language: :elixir}}
+
+    assert {:ok, {{:json, %{"language" => "elixir"}}, [{~c"content-type", ~c"application/json"}]}} =
+             :oidcc_http_util.request(
+               :get,
+               request,
+               %{topic: [:oidcc, :elixir_http_adapter_test]},
+               %{
+                 timeout: 987,
+                 http_adapter: {Oidcc.HttpAdapterTest.Adapter, config}
+               }
+             )
+
+    assert_receive {
+      :adapter_request,
+      :get,
+      ^request,
+      [{:timeout, 987}],
+      [{:body_format, :binary}],
+      ^config
+    }
+  end
+end

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -752,7 +752,6 @@ create_redirect_url_with_par_url_test() ->
     ClientContext =
         oidcc_client_context:from_manual(Configuration, Jwks, ClientId, ClientSecret),
 
-    ok = meck:new(httpc, [no_link]),
     HttpFun =
         fun(
             post,
@@ -783,18 +782,15 @@ create_redirect_url_with_par_url_test() ->
 
             {ok, {{"HTTP/1.1", 201, "OK"}, [{"content-type", "application/json"}], ParResponseData}}
         end,
-    ok = meck:expect(httpc, request, HttpFun),
+    Adapter = {oidcc_http_adapter_test, #{request => HttpFun}},
 
     RedirectUrlResponse = oidcc_authorization:create_redirect_url(ClientContext, #{
         redirect_uri => RedirectUri,
         pkce_verifier => PkceVerifier,
         state => State,
-        nonce => Nonce
+        nonce => Nonce,
+        request_opts => #{http_adapter => Adapter}
     }),
-
-    true = meck:validate(httpc),
-
-    meck:unload(httpc),
 
     ?assertMatch(
         {ok, _},

--- a/test/oidcc_client_registration_test.erl
+++ b/test/oidcc_client_registration_test.erl
@@ -43,7 +43,6 @@ register_test() ->
             ]
         ),
 
-    ok = meck:new(httpc, [no_link]),
     HttpFun =
         fun(
             post,
@@ -65,12 +64,15 @@ register_test() ->
             ),
             {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], ResponseJson}}
         end,
-    ok = meck:expect(httpc, request, HttpFun),
+    Adapter = {oidcc_http_adapter_test, #{request => HttpFun}},
 
     {ok, Response} = oidcc_client_registration:register(Configuration, Registration, #{
-        initial_access_token => <<"token">>
+        initial_access_token => <<"token">>,
+        request_opts => #{http_adapter => Adapter}
     }),
-    {ok, Response} = oidcc_client_registration:register(Configuration, Registration, #{}),
+    {ok, Response} = oidcc_client_registration:register(Configuration, Registration, #{
+        request_opts => #{http_adapter => Adapter}
+    }),
 
     ?assertMatch(#oidcc_client_registration_response{client_id = ClientId}, Response),
 
@@ -91,10 +93,6 @@ register_test() ->
     after 10_000 ->
         ct:fail(timeout_receive_attach_event_handlers)
     end,
-
-    true = meck:validate(httpc),
-
-    meck:unload(httpc),
 
     ok.
 

--- a/test/oidcc_http_adapter_test.erl
+++ b/test/oidcc_http_adapter_test.erl
@@ -1,0 +1,292 @@
+%% SPDX-FileCopyrightText: 2023 Erlang Ecosystem Foundation
+%% SPDX-License-Identifier: Apache-2.0
+
+-module(oidcc_http_adapter_test).
+
+-behaviour(oidcc_http_adapter).
+
+-export([request/5]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+request(Method, Request, HttpOptions, RequestOptions, AdapterConfig) ->
+    RequestFun = maps:get(request, AdapterConfig),
+    RequestFun(Method, Request, HttpOptions, RequestOptions, AdapterConfig).
+
+behaviour_test() ->
+    ?assert(lists:member({request, 5}, oidcc_http_adapter:behaviour_info(callbacks))).
+
+adapter_receives_request_test() ->
+    TestPid = self(),
+    Method = post,
+    Request =
+        {<<"https://example.com/token">>, [{"accept", "application/json"}], "application/json",
+            <<"{}">>},
+    SslOptions = [{verify, verify_none}],
+    RequestFun =
+        fun(ReceivedMethod, ReceivedRequest, HttpOptions, RequestOptions, AdapterConfig) ->
+            TestPid !
+                {adapter_request, ReceivedMethod, ReceivedRequest, HttpOptions, RequestOptions,
+                    AdapterConfig},
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", <<"application/json">>}],
+                <<"{\"ok\":true}">>
+            }}
+        end,
+    AdapterConfig = #{request => RequestFun, custom => #{option => value}},
+
+    ?assertEqual(
+        {ok, {{json, #{<<"ok">> => true}}, [{"content-type", <<"application/json">>}]}},
+        oidcc_http_util:request(Method, Request, telemetry_opts(adapter_request), #{
+            timeout => 1_234,
+            ssl => SslOptions,
+            http_adapter => {?MODULE, AdapterConfig}
+        })
+    ),
+
+    receive
+        {adapter_request, Method, Request, [{ssl, SslOptions}, {timeout, 1_234}],
+            [{body_format, binary}], AdapterConfig} ->
+            ok
+    after 1_000 ->
+        ?assert(false)
+    end.
+
+adapter_jwt_response_test() ->
+    RequestFun =
+        fun(get, {<<"https://example.com/userinfo">>, []}, _HttpOptions, _RequestOptions, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/jwt"}],
+                <<"header.payload.signature">>
+            }}
+        end,
+
+    ?assertEqual(
+        {ok, {{jwt, <<"header.payload.signature">>}, [{"content-type", "application/jwt"}]}},
+        oidcc_http_util:request(
+            get,
+            {<<"https://example.com/userinfo">>, []},
+            telemetry_opts(adapter_jwt_response),
+            #{http_adapter => {?MODULE, #{request => RequestFun}}}
+        )
+    ).
+
+adapter_error_normalization_test() ->
+    TransportErrorFun =
+        fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+            {error, transport_failed}
+        end,
+    ?assertEqual(
+        {error, transport_failed},
+        oidcc_http_util:request(
+            get,
+            {<<"https://example.com">>, []},
+            telemetry_opts(adapter_transport_error),
+            #{http_adapter => {?MODULE, #{request => TransportErrorFun}}}
+        )
+    ),
+
+    ProtocolErrorFun =
+        fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 429, "Too Many Requests"},
+                [{"content-type", "application/json"}],
+                <<"{\"error\":\"slow_down\"}">>
+            }}
+        end,
+    ?assertEqual(
+        {error, {http_error, 429, #{<<"error">> => <<"slow_down">>}}},
+        oidcc_http_util:request(
+            get,
+            {<<"https://example.com">>, []},
+            telemetry_opts(adapter_protocol_error),
+            #{http_adapter => {?MODULE, #{request => ProtocolErrorFun}}}
+        )
+    ).
+
+adapter_telemetry_test() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Topic = [oidcc, adapter_telemetry],
+    HandlerId = {?MODULE, make_ref()},
+    Events = [Topic ++ [start], Topic ++ [stop], Topic ++ [exception]],
+    ok = telemetry:attach_many(
+        HandlerId,
+        Events,
+        fun(Event, Measurements, Metadata, TestPid) ->
+            TestPid ! {telemetry, Event, Measurements, Metadata}
+        end,
+        self()
+    ),
+
+    try
+        SuccessMetadata = #{issuer => <<"https://success.example">>},
+        SuccessFun =
+            fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], <<"{}">>
+                }}
+            end,
+        ?assertMatch(
+            {ok, _},
+            oidcc_http_util:request(
+                get,
+                {<<"https://success.example">>, []},
+                #{topic => Topic, extra_meta => SuccessMetadata},
+                #{http_adapter => {?MODULE, #{request => SuccessFun}}}
+            )
+        ),
+        assert_span(Topic, SuccessMetadata, SuccessMetadata),
+
+        FailureMetadata = #{issuer => <<"https://failure.example">>},
+        FailureFun =
+            fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+                {error, transport_failed}
+            end,
+        ?assertEqual(
+            {error, transport_failed},
+            oidcc_http_util:request(
+                get,
+                {<<"https://failure.example">>, []},
+                #{topic => Topic, extra_meta => FailureMetadata},
+                #{http_adapter => {?MODULE, #{request => FailureFun}}}
+            )
+        ),
+        assert_span(
+            Topic,
+            FailureMetadata,
+            FailureMetadata#{error => transport_failed}
+        ),
+
+        ProtocolFailureMetadata = #{issuer => <<"https://protocol-failure.example">>},
+        ProtocolFailure = {http_error, 503, <<"unavailable">>},
+        ProtocolFailureFun =
+            fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+                {ok, {{"HTTP/1.1", 503, "Service Unavailable"}, [], <<"unavailable">>}}
+            end,
+        ?assertEqual(
+            {error, ProtocolFailure},
+            oidcc_http_util:request(
+                get,
+                {<<"https://protocol-failure.example">>, []},
+                #{topic => Topic, extra_meta => ProtocolFailureMetadata},
+                #{http_adapter => {?MODULE, #{request => ProtocolFailureFun}}}
+            )
+        ),
+        assert_span(
+            Topic,
+            ProtocolFailureMetadata,
+            ProtocolFailureMetadata#{error => ProtocolFailure}
+        )
+    after
+        telemetry:detach(HandlerId)
+    end.
+
+default_adapter_test() ->
+    Request = {<<"https://example.com">>, []},
+    ok = meck:new(oidcc_http_adapter_httpc, [passthrough]),
+    try
+        ok = meck:expect(
+            oidcc_http_adapter_httpc,
+            request,
+            fun(
+                get,
+                ReceivedRequest,
+                [{timeout, 60_000}],
+                [{body_format, binary}],
+                ReceivedAdapterConfig
+            ) ->
+                ?assertEqual(Request, ReceivedRequest),
+                ?assertEqual(#{profile => default}, ReceivedAdapterConfig),
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], <<"{}">>
+                }}
+            end
+        ),
+
+        ?assertMatch(
+            {ok, _},
+            oidcc_http_util:request(get, Request, telemetry_opts(default_adapter), #{})
+        ),
+
+        ?assert(meck:validate(oidcc_http_adapter_httpc))
+    after
+        meck:unload(oidcc_http_adapter_httpc)
+    end.
+
+legacy_httpc_options_test() ->
+    Method = post,
+    Request =
+        {<<"https://example.com/token">>, [{"accept", "application/json"}],
+            "application/x-www-form-urlencoded", <<"grant_type=client_credentials">>},
+    SslOptions = [{verify, verify_none}, {server_name_indication, "example.com"}],
+    Profile = test_profile,
+    ok = meck:new(httpc, [no_link]),
+    try
+        ok = meck:expect(
+            httpc,
+            request,
+            fun(
+                ReceivedMethod,
+                ReceivedRequest,
+                [{ssl, ReceivedSslOptions}, {timeout, 4_321}],
+                [{body_format, binary}],
+                ReceivedProfile
+            ) ->
+                ?assertEqual(Method, ReceivedMethod),
+                ?assertEqual(Request, ReceivedRequest),
+                ?assertEqual(SslOptions, ReceivedSslOptions),
+                ?assertEqual(Profile, ReceivedProfile),
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], <<"{}">>
+                }}
+            end
+        ),
+
+        ?assertMatch(
+            {ok, _},
+            oidcc_http_util:request(Method, Request, telemetry_opts(legacy_httpc_options), #{
+                timeout => 4_321,
+                ssl => SslOptions,
+                httpc_profile => Profile
+            })
+        ),
+
+        ?assert(meck:validate(httpc))
+    after
+        meck:unload(httpc)
+    end.
+
+telemetry_opts(Name) ->
+    #{topic => [oidcc, Name]}.
+
+assert_span(Topic, StartMetadata, StopMetadata) ->
+    ActualStartMetadata =
+        receive
+            {telemetry, StartEvent, #{system_time := _}, ReceivedStartMetadata} ->
+                ?assertEqual(Topic ++ [start], StartEvent),
+                ReceivedStartMetadata
+        after 1_000 ->
+            ?assert(false)
+        end,
+    ActualStopMetadata =
+        receive
+            {telemetry, StopEvent, #{duration := _, monotonic_time := _}, ReceivedStopMetadata} ->
+                ?assertEqual(Topic ++ [stop], StopEvent),
+                ReceivedStopMetadata
+        after 1_000 ->
+            ?assert(false)
+        end,
+    ?assertEqual(
+        StartMetadata,
+        maps:without([telemetry_span_context], ActualStartMetadata)
+    ),
+    ?assertEqual(
+        StopMetadata,
+        maps:without([telemetry_span_context], ActualStopMetadata)
+    ),
+    ?assertEqual(
+        maps:get(telemetry_span_context, ActualStartMetadata),
+        maps:get(telemetry_span_context, ActualStopMetadata)
+    ).

--- a/test/oidcc_provider_configuration_worker_test.erl
+++ b/test/oidcc_provider_configuration_worker_test.erl
@@ -70,61 +70,61 @@ retries_with_backoff_with_invalid_issuer_test() ->
     ok.
 
 refreshes_with_empty_key_set_test() ->
-    ok = meck:new(httpc, [no_link]),
-    HttpFun =
-        fun
-            (
-                get,
-                {"https://example.com/.well-known/openid-configuration", []},
-                _HttpOpts,
-                _Opts,
-                _Profile
-            ) ->
-                {ok, {
-                    {"HTTP/1.1", 200, "OK"},
-                    [{"content-type", "application/json"}],
-                    jsx:encode(#{
-                        issuer => <<"https://example.com">>,
-                        jwks_uri => <<"https://example.com/keys">>,
-                        authorization_endpoint => <<"https://example.com/authorize">>,
-                        scopes_supported => [<<"openid">>],
-                        response_types_supported => [<<"code">>],
-                        subject_types_supported => [<<"public">>],
-                        id_token_signing_alg_values_supported => [<<"RS256">>]
-                    })
-                }};
-            (
-                get,
-                {<<"https://example.com/keys">>, []},
-                _HttpOpts,
-                _Opts,
-                _Profile
-            ) ->
-                {ok, {
-                    {"HTTP/1.1", 200, "OK"},
-                    [{"content-type", "application/json"}],
-                    jsx:encode(#{keys => []})
-                }}
-        end,
-    ok = meck:expect(httpc, request, HttpFun),
-
-    process_flag(trap_exit, true),
+    Adapter = provider_adapter(self()),
 
     {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
         issuer => <<"https://example.com">>,
+        provider_configuration_opts => #{
+            request_opts => #{http_adapter => Adapter}
+        },
         backoff_type => random,
         backoff_min => 500,
         backoff_max => 500
     }),
 
-    ok = oidcc_provider_configuration_worker:refresh_jwks_for_unknown_kid(Pid, <<"kid">>),
+    try
+        ?assertMatch(
+            #jose_jwk{keys = {jose_jwk_set, []}},
+            wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
+        ),
+        assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
+        assert_adapter_request(<<"https://example.com/keys">>),
 
-    % Once for Metadata, once for JWKs, and once for JWK refresh
-    ?assert(meck:num_calls(httpc, request, '_') >= 3),
+        ok = oidcc_provider_configuration_worker:refresh_configuration(Pid),
+        assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
 
-    meck:unload(httpc),
+        ok = oidcc_provider_configuration_worker:refresh_jwks(Pid),
+        assert_adapter_request(<<"https://example.com/keys">>),
 
-    ok.
+        ok = oidcc_provider_configuration_worker:refresh_jwks_for_unknown_kid(Pid, <<"kid">>),
+        assert_adapter_request(<<"https://example.com/keys">>)
+    after
+        gen_server:stop(Pid)
+    end.
+
+refreshes_in_background_with_adapter_test() ->
+    Adapter = provider_adapter(self()),
+
+    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
+        issuer => <<"https://example.com">>,
+        provider_configuration_opts => #{
+            fallback_expiry => 50,
+            request_opts => #{http_adapter => Adapter}
+        }
+    }),
+
+    try
+        ?assertMatch(
+            #jose_jwk{keys = {jose_jwk_set, []}},
+            wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
+        ),
+        assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
+        assert_adapter_request(<<"https://example.com/keys">>),
+        assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
+        assert_adapter_request(<<"https://example.com/keys">>)
+    after
+        gen_server:stop(Pid)
+    end.
 
 %% Discovery / JWKS responses carrying `Cache-Control: max-age=0' used to
 %% crash the worker because the parser returned the atom `true' as the
@@ -268,3 +268,52 @@ wait_until(Fun, Retries) ->
         Value ->
             Value
     end.
+
+assert_adapter_request(ExpectedUrl) ->
+    receive
+        {adapter_request, ExpectedUrl} ->
+            ok
+    after 1_000 ->
+        ?assert(false)
+    end.
+
+provider_adapter(TestPid) ->
+    HttpFun =
+        fun
+            (
+                get,
+                {"https://example.com/.well-known/openid-configuration", []},
+                _HttpOpts,
+                _Opts,
+                _AdapterConfig
+            ) ->
+                TestPid !
+                    {adapter_request, <<"https://example.com/.well-known/openid-configuration">>},
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [{"content-type", "application/json"}],
+                    jsx:encode(#{
+                        issuer => <<"https://example.com">>,
+                        jwks_uri => <<"https://example.com/keys">>,
+                        authorization_endpoint => <<"https://example.com/authorize">>,
+                        scopes_supported => [<<"openid">>],
+                        response_types_supported => [<<"code">>],
+                        subject_types_supported => [<<"public">>],
+                        id_token_signing_alg_values_supported => [<<"RS256">>]
+                    })
+                }};
+            (
+                get,
+                {<<"https://example.com/keys">>, []},
+                _HttpOpts,
+                _Opts,
+                _AdapterConfig
+            ) ->
+                TestPid ! {adapter_request, <<"https://example.com/keys">>},
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [{"content-type", "application/json"}],
+                    jsx:encode(#{keys => []})
+                }}
+        end,
+    {oidcc_http_adapter_test, #{request => HttpFun}}.

--- a/test/oidcc_provider_configuration_worker_test.erl
+++ b/test/oidcc_provider_configuration_worker_test.erl
@@ -13,118 +13,111 @@ does_not_start_without_issuer_test() ->
     ).
 
 stops_with_invalid_issuer_test() ->
-    ok = meck:new(httpc, [no_link]),
     HttpFun =
         fun(get, _Request, _HttpOpts, _Opts, _Profile) ->
             {ok, {{"HTTP/1.1", 501, "Not Implemented"}, [], ""}}
         end,
-    ok = meck:expect(httpc, request, HttpFun),
 
-    process_flag(trap_exit, true),
-
-    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{issuer => <<"http://example.com">>}),
-
-    receive
-        {'EXIT', Pid, {configuration_load_failed, _Error}} -> ok
-    after 10000 ->
-        ?assert(false)
-    end,
-
-    meck:unload(httpc),
-
-    ok.
+    with_httpc_mock(HttpFun, fun() ->
+        with_stopping_provider_worker(#{issuer => <<"http://example.com">>}, fun(Pid) ->
+            receive
+                {'EXIT', Pid, {configuration_load_failed, _Error}} ->
+                    ok;
+                {'EXIT', Pid, Reason} ->
+                    ct:fail({unexpected_exit, Reason})
+            after 1_000 ->
+                ?assert(false)
+            end
+        end)
+    end).
 
 retries_with_backoff_with_invalid_issuer_test() ->
-    ok = meck:new(httpc, [no_link]),
     HttpFun =
         fun(get, _Request, _HttpOpts, _Opts, _Profile) ->
             {ok, {{"HTTP/1.1", 501, "Not Implemented"}, [], ""}}
         end,
-    ok = meck:expect(httpc, request, HttpFun),
 
-    process_flag(trap_exit, true),
+    with_httpc_mock(HttpFun, fun() ->
+        with_live_provider_worker(
+            #{
+                issuer => <<"http://example.com">>,
+                backoff_type => random,
+                backoff_min => 500,
+                backoff_max => 500
+            },
+            fun(Pid) ->
+                receive
+                    {'EXIT', Pid, Reason} ->
+                        ct:fail({unexpected_exit, Reason})
+                after 1_000 ->
+                    ok
+                end,
 
-    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
-        issuer => <<"http://example.com">>,
-        backoff_type => random,
-        backoff_min => 500,
-        backoff_max => 500
-    }),
+                ?assertMatch(
+                    {error, provider_not_ready},
+                    oidcc:create_redirect_url(Pid, <<"client_id">>, <<"client_secret">>, #{
+                        redirect_uri => "http://example.com"
+                    })
+                ),
 
-    receive
-        {'EXIT', Pid, {configuration_load_failed, _Error}} -> ct:fail(should_not_exit)
-    after 1_000 -> ok
-    end,
-
-    ?assertMatch(
-        {error, provider_not_ready},
-        oidcc:create_redirect_url(Pid, <<"client_id">>, <<"client_secret">>, #{
-            redirect_uri => "http://example.com"
-        })
-    ),
-
-    ?assert(meck:num_calls(httpc, request, '_') >= 2),
-
-    meck:unload(httpc),
-
-    ok.
+                ?assert(meck:num_calls(httpc, request, '_') >= 2)
+            end
+        )
+    end).
 
 refreshes_with_empty_key_set_test() ->
     Adapter = provider_adapter(self()),
 
-    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
-        issuer => <<"https://example.com">>,
-        provider_configuration_opts => #{
-            request_opts => #{http_adapter => Adapter}
+    with_live_provider_worker(
+        #{
+            issuer => <<"https://example.com">>,
+            provider_configuration_opts => #{
+                request_opts => #{http_adapter => Adapter}
+            },
+            backoff_type => random,
+            backoff_min => 500,
+            backoff_max => 500
         },
-        backoff_type => random,
-        backoff_min => 500,
-        backoff_max => 500
-    }),
+        fun(Pid) ->
+            ?assertMatch(
+                #jose_jwk{keys = {jose_jwk_set, []}},
+                wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
+            ),
+            assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
+            assert_adapter_request(<<"https://example.com/keys">>),
 
-    try
-        ?assertMatch(
-            #jose_jwk{keys = {jose_jwk_set, []}},
-            wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
-        ),
-        assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
-        assert_adapter_request(<<"https://example.com/keys">>),
+            ok = oidcc_provider_configuration_worker:refresh_configuration(Pid),
+            assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
 
-        ok = oidcc_provider_configuration_worker:refresh_configuration(Pid),
-        assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
+            ok = oidcc_provider_configuration_worker:refresh_jwks(Pid),
+            assert_adapter_request(<<"https://example.com/keys">>),
 
-        ok = oidcc_provider_configuration_worker:refresh_jwks(Pid),
-        assert_adapter_request(<<"https://example.com/keys">>),
-
-        ok = oidcc_provider_configuration_worker:refresh_jwks_for_unknown_kid(Pid, <<"kid">>),
-        assert_adapter_request(<<"https://example.com/keys">>)
-    after
-        gen_server:stop(Pid)
-    end.
+            ok = oidcc_provider_configuration_worker:refresh_jwks_for_unknown_kid(Pid, <<"kid">>),
+            assert_adapter_request(<<"https://example.com/keys">>)
+        end
+    ).
 
 refreshes_in_background_with_adapter_test() ->
-    Adapter = provider_adapter(self()),
+    Adapter = background_provider_adapter(self()),
 
-    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
-        issuer => <<"https://example.com">>,
-        provider_configuration_opts => #{
-            fallback_expiry => 50,
-            request_opts => #{http_adapter => Adapter}
-        }
-    }),
-
-    try
-        ?assertMatch(
-            #jose_jwk{keys = {jose_jwk_set, []}},
-            wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
-        ),
-        assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
-        assert_adapter_request(<<"https://example.com/keys">>),
-        assert_adapter_request(<<"https://example.com/.well-known/openid-configuration">>),
-        assert_adapter_request(<<"https://example.com/keys">>)
-    after
-        gen_server:stop(Pid)
-    end.
+    with_live_provider_worker(
+        #{
+            issuer => <<"https://example.com">>,
+            provider_configuration_opts => #{
+                fallback_expiry => 50,
+                request_opts => #{http_adapter => Adapter}
+            }
+        },
+        fun(Pid) ->
+            ?assertMatch(
+                #jose_jwk{keys = {jose_jwk_set, []}},
+                wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
+            ),
+            assert_adapter_request(1, <<"https://example.com/.well-known/openid-configuration">>),
+            assert_adapter_request(2, <<"https://example.com/keys">>),
+            assert_background_adapter_refresh()
+        end
+    ).
 
 %% Discovery / JWKS responses carrying `Cache-Control: max-age=0' used to
 %% crash the worker because the parser returned the atom `true' as the
@@ -133,7 +126,6 @@ refreshes_in_background_with_adapter_test() ->
 %% expiry — including the literal `max-age=0' — flows through the
 %% backoff/retry path and the worker keeps running.
 survives_cache_control_max_age_zero_test() ->
-    ok = meck:new(httpc, [no_link]),
     DiscoveryBody = jsx:encode(#{
         issuer => <<"https://example.com">>,
         jwks_uri => <<"https://example.com/keys">>,
@@ -176,25 +168,26 @@ survives_cache_control_max_age_zero_test() ->
                     jsx:encode(#{keys => []})
                 }}
         end,
-    ok = meck:expect(httpc, request, HttpFun),
 
-    process_flag(trap_exit, true),
-
-    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
-        issuer => <<"https://example.com">>,
-        backoff_type => random,
-        backoff_min => 500,
-        backoff_max => 500
-    }),
-
-    ?assertNotEqual(
-        undefined,
-        wait_until(fun() -> oidcc_provider_configuration_worker:get_provider_configuration(Pid) end)
-    ),
-    ?assert(is_process_alive(Pid)),
-
-    meck:unload(httpc),
-    ok.
+    with_httpc_mock(HttpFun, fun() ->
+        with_live_provider_worker(
+            #{
+                issuer => <<"https://example.com">>,
+                backoff_type => random,
+                backoff_min => 500,
+                backoff_max => 500
+            },
+            fun(Pid) ->
+                ?assertNotEqual(
+                    undefined,
+                    wait_until(fun() ->
+                        oidcc_provider_configuration_worker:get_provider_configuration(Pid)
+                    end)
+                ),
+                ?assert(is_process_alive(Pid))
+            end
+        )
+    end).
 
 %% RFC 6838 §4.2.8 — `application/<subtype>+json' content-types are JSON
 %% with extra contract. Previously only `application/jwk-set+json' was
@@ -202,7 +195,6 @@ survives_cache_control_max_age_zero_test() ->
 %% vendor-prefixed variants, etc.) fell into the `unknown' branch and
 %% the JWKS load failed with `invalid_content_type'.
 accepts_generic_plus_json_content_type_test() ->
-    ok = meck:new(httpc, [no_link]),
     HttpFun =
         fun
             (
@@ -238,22 +230,92 @@ accepts_generic_plus_json_content_type_test() ->
                     jsx:encode(#{keys => []})
                 }}
         end,
-    ok = meck:expect(httpc, request, HttpFun),
 
-    {ok, Pid} = oidcc_provider_configuration_worker:start_link(#{
-        issuer => <<"https://example.com">>,
-        backoff_type => random,
-        backoff_min => 500,
-        backoff_max => 500
-    }),
+    with_httpc_mock(HttpFun, fun() ->
+        with_live_provider_worker(
+            #{
+                issuer => <<"https://example.com">>,
+                backoff_type => random,
+                backoff_min => 500,
+                backoff_max => 500
+            },
+            fun(Pid) ->
+                ?assertMatch(
+                    #jose_jwk{keys = {jose_jwk_set, []}},
+                    wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
+                )
+            end
+        )
+    end).
 
-    ?assertMatch(
-        #jose_jwk{keys = {jose_jwk_set, []}},
-        wait_until(fun() -> oidcc_provider_configuration_worker:get_jwks(Pid) end)
-    ),
+with_httpc_mock(HttpFun, TestFun) ->
+    ok = meck:new(httpc, [no_link]),
+    try
+        ok = meck:expect(httpc, request, HttpFun),
+        TestFun()
+    after
+        meck:unload(httpc)
+    end.
 
-    meck:unload(httpc),
-    ok.
+with_live_provider_worker(Options, TestFun) ->
+    with_trap_exit(fun() ->
+        {ok, Pid} = oidcc_provider_configuration_worker:start_link(Options),
+        try
+            Result = TestFun(Pid),
+            assert_provider_worker_alive(Pid),
+            ok = gen_server:stop(Pid),
+            ?assertEqual({exit, normal}, receive_provider_worker_exit(Pid)),
+            Result
+        catch
+            Class:Reason:Stacktrace ->
+                case stop_provider_worker(Pid) of
+                    {exit, normal} ->
+                        erlang:raise(Class, Reason, Stacktrace);
+                    {exit, WorkerReason} ->
+                        ct:fail({provider_worker_exited, WorkerReason});
+                    none ->
+                        erlang:raise(Class, Reason, Stacktrace)
+                end
+        end
+    end).
+
+with_stopping_provider_worker(Options, TestFun) ->
+    with_trap_exit(fun() ->
+        {ok, Pid} = oidcc_provider_configuration_worker:start_link(Options),
+        try
+            TestFun(Pid)
+        after
+            stop_provider_worker(Pid)
+        end
+    end).
+
+with_trap_exit(TestFun) ->
+    PreviousTrapExit = process_flag(trap_exit, true),
+    try
+        TestFun()
+    after
+        process_flag(trap_exit, PreviousTrapExit)
+    end.
+
+assert_provider_worker_alive(Pid) ->
+    receive
+        {'EXIT', Pid, Reason} ->
+            ct:fail({provider_worker_exited, Reason})
+    after 0 ->
+        ?assert(is_process_alive(Pid))
+    end.
+
+stop_provider_worker(Pid) ->
+    _ = catch gen_server:stop(Pid),
+    receive_provider_worker_exit(Pid).
+
+receive_provider_worker_exit(Pid) ->
+    receive
+        {'EXIT', Pid, Reason} ->
+            {exit, Reason}
+    after 100 ->
+        none
+    end.
 
 wait_until(Fun) ->
     wait_until(Fun, 20).
@@ -277,7 +339,37 @@ assert_adapter_request(ExpectedUrl) ->
         ?assert(false)
     end.
 
+assert_adapter_request(ExpectedRequestNumber, ExpectedUrl) ->
+    ?assertEqual(
+        {ExpectedRequestNumber, ExpectedUrl},
+        receive_adapter_request()
+    ).
+
+assert_background_adapter_refresh() ->
+    ?assertEqual(
+        lists:sort([
+            {3, <<"https://example.com/.well-known/openid-configuration">>},
+            {4, <<"https://example.com/keys">>}
+        ]),
+        lists:sort([receive_adapter_request(), receive_adapter_request()])
+    ).
+
+receive_adapter_request() ->
+    receive
+        {adapter_request, RequestNumber, Url} ->
+            {RequestNumber, Url}
+    after 1_000 ->
+        ?assert(false)
+    end.
+
 provider_adapter(TestPid) ->
+    provider_adapter(TestPid, uncounted).
+
+background_provider_adapter(TestPid) ->
+    Counter = atomics:new(1, []),
+    provider_adapter(TestPid, {counted, Counter}).
+
+provider_adapter(TestPid, AdapterState) ->
     HttpFun =
         fun
             (
@@ -287,11 +379,11 @@ provider_adapter(TestPid) ->
                 _Opts,
                 _AdapterConfig
             ) ->
-                TestPid !
-                    {adapter_request, <<"https://example.com/.well-known/openid-configuration">>},
+                Url = <<"https://example.com/.well-known/openid-configuration">>,
+                AdditionalHeaders = adapter_response_headers(TestPid, AdapterState, Url),
                 {ok, {
                     {"HTTP/1.1", 200, "OK"},
-                    [{"content-type", "application/json"}],
+                    [{"content-type", "application/json"} | AdditionalHeaders],
                     jsx:encode(#{
                         issuer => <<"https://example.com">>,
                         jwks_uri => <<"https://example.com/keys">>,
@@ -309,11 +401,25 @@ provider_adapter(TestPid) ->
                 _Opts,
                 _AdapterConfig
             ) ->
-                TestPid ! {adapter_request, <<"https://example.com/keys">>},
+                Url = <<"https://example.com/keys">>,
+                AdditionalHeaders = adapter_response_headers(TestPid, AdapterState, Url),
                 {ok, {
                     {"HTTP/1.1", 200, "OK"},
-                    [{"content-type", "application/json"}],
+                    [{"content-type", "application/json"} | AdditionalHeaders],
                     jsx:encode(#{keys => []})
                 }}
         end,
     {oidcc_http_adapter_test, #{request => HttpFun}}.
+
+adapter_response_headers(TestPid, uncounted, Url) ->
+    TestPid ! {adapter_request, Url},
+    [];
+adapter_response_headers(TestPid, {counted, Counter}, Url) ->
+    RequestNumber = atomics:add_get(Counter, 1, 1),
+    TestPid ! {adapter_request, RequestNumber, Url},
+    case RequestNumber =< 2 of
+        true ->
+            [];
+        false ->
+            [{"cache-control", "max-age=3600"}]
+    end.

--- a/test/oidcc_token_introspection_test.erl
+++ b/test/oidcc_token_introspection_test.erl
@@ -25,33 +25,37 @@ introspect_test() ->
 
     ClientContext = oidcc_client_context:from_manual(Configuration, Jwks, ClientId, ClientSecret),
 
-    ok = meck:new(oidcc_http_util, [passthrough]),
     HttpFun =
         fun(
             post,
             {ReqEndpoint, _Header, "application/x-www-form-urlencoded", _Body},
-            _TelemetryOpts,
-            _RequestOpts
+            _HttpOptions,
+            _RequestOptions,
+            _AdapterConfig
         ) ->
             IntrospectionEndpoint = ReqEndpoint,
-            {ok,
-                {
-                    {json, #{
-                        <<"active">> => true,
-                        <<"client_id">> => ClientId,
-                        <<"extra">> => <<"value">>
-                    }},
-                    []
-                }}
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/json"}],
+                jsx:encode(#{
+                    <<"active">> => true,
+                    <<"client_id">> => ClientId,
+                    <<"extra">> => <<"value">>
+                })
+            }}
         end,
-    ok = meck:expect(oidcc_http_util, request, HttpFun),
+    RequestOpts = #{
+        request_opts => #{
+            http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}
+        }
+    },
 
     ?assertMatch(
         {ok, #oidcc_token_introspection{active = true, extra = #{<<"extra">> := <<"value">>}}},
         oidcc_token_introspection:introspect(
             AccessToken,
             ClientContext,
-            #{}
+            RequestOpts
         )
     ),
 
@@ -60,7 +64,7 @@ introspect_test() ->
         oidcc_token_introspection:introspect(
             #oidcc_token{access = #oidcc_token_access{token = AccessToken}},
             ClientContext,
-            #{}
+            RequestOpts
         )
     ),
 
@@ -69,13 +73,9 @@ introspect_test() ->
         oidcc_token_introspection:introspect(
             #oidcc_token{access = #oidcc_token_access{token = AccessToken}},
             ClientContext,
-            #{client_self_only => true}
+            RequestOpts#{client_self_only => true}
         )
     ),
-
-    true = meck:validate(oidcc_http_util),
-
-    meck:unload(oidcc_http_util),
 
     ok.
 

--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -73,7 +73,6 @@ retrieve_none_test() ->
 
     ClientContext = oidcc_client_context:from_manual(Configuration, JwkSet, ClientId, ClientSecret),
 
-    ok = meck:new(httpc, [no_link]),
     HttpFun =
         fun(
             post,
@@ -95,7 +94,7 @@ retrieve_none_test() ->
             ),
             {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], TokenData}}
         end,
-    ok = meck:expect(httpc, request, HttpFun),
+    Adapter = {oidcc_http_adapter_test, #{request => HttpFun}},
 
     jose:unsecured_signing(false),
 
@@ -113,7 +112,8 @@ retrieve_none_test() ->
             #{
                 redirect_uri => LocalEndpoint,
                 url_extension => [{<<"foo">>, <<"bar">>}],
-                body_extension => [{<<"foo">>, <<"bar">>}]
+                body_extension => [{<<"foo">>, <<"bar">>}],
+                request_opts => #{http_adapter => Adapter}
             }
         )
     ),
@@ -127,10 +127,6 @@ retrieve_none_test() ->
     after 2_000 ->
         ct:fail(timeout_receive_attach_event_handlers)
     end,
-
-    true = meck:validate(httpc),
-
-    meck:unload(httpc),
 
     ok.
 

--- a/test/oidcc_userinfo_test.erl
+++ b/test/oidcc_userinfo_test.erl
@@ -33,8 +33,11 @@ json_test() ->
             Url = UserInfoEndpoint,
             {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], HttpBody}}
         end,
-    ok = meck:new(httpc),
-    ok = meck:expect(httpc, request, HttpFun),
+    RequestOpts = #{
+        request_opts => #{
+            http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}
+        }
+    },
 
     AccessToken = <<"opensesame">>,
     GoodToken =
@@ -58,11 +61,11 @@ json_test() ->
 
     ?assertMatch(
         {ok, #{<<"name">> := <<"joe">>}},
-        oidcc_userinfo:retrieve(GoodToken, ClientContext, #{})
+        oidcc_userinfo:retrieve(GoodToken, ClientContext, RequestOpts)
     ),
     ?assertMatch(
         {ok, #{<<"name">> := <<"joe">>}},
-        oidcc_userinfo:retrieve(AccessTokenRecord, ClientContext, #{
+        oidcc_userinfo:retrieve(AccessTokenRecord, ClientContext, RequestOpts#{
             expected_subject => GoodSub
         })
     ),
@@ -71,20 +74,20 @@ json_test() ->
         oidcc_userinfo:retrieve(
             AccessToken,
             ClientContext,
-            #{expected_subject => GoodSub}
+            RequestOpts#{expected_subject => GoodSub}
         )
     ),
 
     ?assertMatch(
         {error, bad_subject},
-        oidcc_userinfo:retrieve(BadToken, ClientContext, #{})
+        oidcc_userinfo:retrieve(BadToken, ClientContext, RequestOpts)
     ),
     ?assertMatch(
         {error, bad_subject},
         oidcc_userinfo:retrieve(
             AccessToken,
             ClientContext,
-            #{expected_subject => BadSub}
+            RequestOpts#{expected_subject => BadSub}
         )
     ),
     ?assertMatch(
@@ -92,12 +95,9 @@ json_test() ->
         oidcc_userinfo:retrieve(
             AccessToken,
             ClientContext,
-            #{expected_subject => any}
+            RequestOpts#{expected_subject => any}
         )
     ),
-
-    true = meck:validate(httpc),
-    meck:unload(httpc),
 
     ok.
 
@@ -314,36 +314,41 @@ distributed_claims_test() ->
         ),
 
     HttpFun =
-        fun(get, {Url, _Header}, _TelemetryOpts, _RequestOpts) ->
+        fun(get, {Url, _Header}, _HttpOptions, _RequestOptions, _AdapterConfig) ->
             case Url of
                 UserInfoEndpoint ->
-                    {ok,
-                        {
-                            {json, #{
-                                <<"sub">> => Sub,
-                                <<"_claim_names">> => #{
-                                    <<"first_name">> => <<"remote">>,
-                                    <<"last_name">> => <<"local">>
+                    {ok, {
+                        {"HTTP/1.1", 200, "OK"},
+                        [{"content-type", "application/json"}],
+                        jsx:encode(#{
+                            <<"sub">> => Sub,
+                            <<"_claim_names">> => #{
+                                <<"first_name">> => <<"remote">>,
+                                <<"last_name">> => <<"local">>
+                            },
+                            <<"_claim_sources">> => #{
+                                <<"remote">> => #{
+                                    <<"endpoint">> =>
+                                        <<"https://my.provider/distributed-claim">>,
+                                    <<"access_token">> => <<"acces_token">>
                                 },
-                                <<"_claim_sources">> => #{
-                                    <<"remote">> => #{
-                                        <<"endpoint">> =>
-                                            <<"https://my.provider/distributed-claim">>,
-                                        <<"access_token">> => <<"acces_token">>
-                                    },
-                                    <<"local">> => #{
-                                        <<"JWT">> => LocalToken
-                                    }
+                                <<"local">> => #{
+                                    <<"JWT">> => LocalToken
                                 }
-                            }},
-                            []
-                        }};
+                            }
+                        })
+                    }};
                 <<"https://my.provider/distributed-claim">> ->
-                    {ok, {{jwt, RemoteToken}, []}}
+                    {ok, {
+                        {"HTTP/1.1", 200, "OK"}, [{"content-type", "application/jwt"}], RemoteToken
+                    }}
             end
         end,
-    ok = meck:new(oidcc_http_util, [passthrough]),
-    ok = meck:expect(oidcc_http_util, request, HttpFun),
+    RequestOpts = #{
+        request_opts => #{
+            http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}
+        }
+    },
 
     AccessToken = <<"opensesame">>,
     Token =
@@ -358,19 +363,16 @@ distributed_claims_test() ->
 
     ?assertMatch(
         {ok, #{<<"first_name">> := <<"Joe">>, <<"last_name">> := <<"Armstrong">>}},
-        oidcc_userinfo:retrieve(Token, ClientContext, #{})
+        oidcc_userinfo:retrieve(Token, ClientContext, RequestOpts)
     ),
     ?assertMatch(
         {ok, #{<<"first_name">> := <<"Joe">>, <<"last_name">> := <<"Armstrong">>}},
         oidcc_userinfo:retrieve(
             AccessToken,
             ClientContext,
-            #{expected_subject => Sub}
+            RequestOpts#{expected_subject => Sub}
         )
     ),
-
-    true = meck:validate(oidcc_http_util),
-    meck:unload(oidcc_http_util),
 
     ok.
 


### PR DESCRIPTION
Add a public `oidcc_http_adapter` behavior and a default `oidcc_http_adapter_httpc` implementation so applications can control the HTTP transport while retaining OIDCC's existing protocol handling.

- Pass the original request tuple, HTTP options, binary-body option, and adapter-specific configuration through `request_opts.http_adapter`.
- Preserve the default `httpc` profile, timeout, TLS, response parsing, DPoP nonce handling, error normalization, and telemetry behavior when no adapter is configured.
- Keep provider discovery and JWKS adapter configuration separate from later operation-level configuration, with Erlang and Elixir examples.
- Correct public option types and add adapter-backed coverage across every outbound request path, including provider background refresh.

This lets consumers implement destination validation, address pinning, redirect handling, and response-size limits without adding another HTTP client dependency to OIDCC.

Validated with `rebar3 fmt --check`, `mix format --check-formatted`, `rebar3 eunit`, `rebar3 ct`, `mix test`, `rebar3 lint`, `rebar3 hank`, `rebar3 dialyzer`, `mix credo`, and `mix dialyzer`.
