### PR TITLE
Use OTP's built-in json module instead of jose/jsx

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,6 @@ defmodule Oidcc.Mixfile do
       {:telemetry, "~> 1.2"},
       {:telemetry_registry, "~> 0.3.1"},
       {:jose, "~> 1.11"},
-      {:jsx, "~> 3.1", only: :test},
       {:mock, "~> 0.3.8", only: :test},
       {:ex_doc, "~> 0.29", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: :dev, runtime: false},

--- a/rebar.config
+++ b/rebar.config
@@ -32,8 +32,7 @@
 {profiles, [
     {test, [
         {deps, [
-            {meck, "~> 0.9.2"},
-            {jsx, "~> 3.1"}
+            {meck, "~> 0.9.2"}
         ]},
         {cover_enabled, true},
         {cover_export_enabled, true},

--- a/src/oidcc.erl
+++ b/src/oidcc.erl
@@ -347,7 +347,7 @@ See https://datatracker.ietf.org/doc/html/rfc7523#section-4.
 
 ```erlang
 {ok, KeyJson} = file:read_file("jwt-profile.json"),
-KeyMap = jose:decode(KeyJson),
+KeyMap = json:decode(KeyJson),
 Key = jose_jwk:from_pem(maps:get(<<"key">>, KeyMap)),
 
 {ok, #oidcc_token{}} =

--- a/src/oidcc_client_registration.erl
+++ b/src/oidcc_client_registration.erl
@@ -360,4 +360,4 @@ encode(#oidcc_client_registration{
         end,
         Map1
     ),
-    jose:encode(Map).
+    iolist_to_binary(json:encode(Map)).

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -142,7 +142,7 @@ extract_successful_response({{_HttpVersion, Status, _HttpStatusName}, Headers, H
 ->
     case fetch_content_type(Headers) of
         json ->
-            {ok, {json, jose:decode(HttpBodyResult)}};
+            {ok, {json, json:decode(HttpBodyResult)}};
         jwt ->
             {ok, {jwt, HttpBodyResult}};
         unknown ->
@@ -152,7 +152,7 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
     Body =
         case fetch_content_type(Headers) of
             json ->
-                jose:decode(HttpBodyResult);
+                json:decode(HttpBodyResult);
             jwt ->
                 HttpBodyResult;
             unknown ->

--- a/src/oidcc_token.erl
+++ b/src/oidcc_token.erl
@@ -587,7 +587,7 @@ see {@link oidcc:jwt_profile_token/6}.
                                                  <<"client_secret">>),
 
 {ok, KeyJson} = file:read_file("jwt-profile.json"),
-KeyMap = jose:decode(KeyJson),
+KeyMap = json:decode(KeyJson),
 Key = jose_jwk:from_pem(maps:get(<<"key">>, KeyMap)),
 
 {ok, #oidcc_token{}} =

--- a/test/oidcc_SUITE.erl
+++ b/test/oidcc_SUITE.erl
@@ -161,7 +161,7 @@ retrieve_jwt_profile_token(_Config) ->
     PrivDir = code:priv_dir(oidcc),
 
     {ok, KeyJson} = file:read_file(PrivDir ++ "/test/fixtures/zitadel-jwt-profile.json"),
-    KeyMap = jose:decode(KeyJson),
+    KeyMap = json:decode(KeyJson),
     Key = jose_jwk:from_pem(maps:get(<<"key">>, KeyMap)),
 
     application:set_env(oidcc, max_clock_skew, 10),
@@ -197,7 +197,7 @@ retrieve_client_credentials_token(_Config) ->
     #{
         <<"clientId">> := ZitadelClientCredentialsClientId,
         <<"clientSecret">> := ZitadelClientCredentialsClientSecret
-    } = jose:decode(ZitadelClientCredentialsJson),
+    } = json:decode(ZitadelClientCredentialsJson),
 
     ?assertMatch(
         {ok, _},

--- a/test/oidcc_authorization_test.erl
+++ b/test/oidcc_authorization_test.erl
@@ -15,7 +15,7 @@ create_redirect_url_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
     PkcePlainConfiguration = Configuration#oidcc_provider_configuration{
         code_challenge_methods_supported = [<<"plain">>]
@@ -146,7 +146,7 @@ create_redirect_url_with_request_object_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{issuer = Issuer} = Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -257,7 +257,7 @@ create_redirect_url_with_request_object_and_max_clock_skew_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{} = Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -340,7 +340,7 @@ create_redirect_url_with_request_object_no_hmac_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{} = Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -414,7 +414,7 @@ create_redirect_url_with_invalid_request_object_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -465,7 +465,7 @@ create_redirect_url_with_missing_config_request_object_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -513,7 +513,7 @@ create_redirect_url_with_missing_config_request_object_required_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -546,7 +546,7 @@ create_redirect_url_with_request_object_only_none_alg_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -602,7 +602,7 @@ create_redirect_url_with_request_object_only_none_alg_unsecured_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -691,7 +691,7 @@ create_redirect_url_with_par_required_no_url_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -725,7 +725,7 @@ create_redirect_url_with_par_url_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -733,10 +733,12 @@ create_redirect_url_with_par_url_test() ->
     },
 
     ParResponseData =
-        jsx:encode(#{
-            <<"request_uri">> => <<"urn:ietf:params:oauth:request_uri:par_response">>,
-            <<"expires_in">> => 60
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"request_uri">> => <<"urn:ietf:params:oauth:request_uri:par_response">>,
+                <<"expires_in">> => 60
+            })
+        ),
 
     ClientId = <<"client_id">>,
     ClientSecret = <<"at_least_32_character_client_secret">>,
@@ -824,7 +826,7 @@ create_redirect_url_with_par_error_when_required_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -833,9 +835,11 @@ create_redirect_url_with_par_error_when_required_test() ->
     },
 
     ParResponseData =
-        jsx:encode(#{
-            <<"error">> => <<"invalid_request">>
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"error">> => <<"invalid_request">>
+            })
+        ),
 
     ClientId = <<"client_id">>,
     ClientSecret = <<"at_least_32_character_client_secret">>,
@@ -881,7 +885,7 @@ create_redirect_url_with_par_invalid_response_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -890,7 +894,7 @@ create_redirect_url_with_par_invalid_response_test() ->
     },
 
     %% no request_uri
-    ParResponseData = jsx:encode(#{}),
+    ParResponseData = iolist_to_binary(json:encode(#{})),
 
     ClientId = <<"client_id">>,
     ClientSecret = <<"at_least_32_character_client_secret">>,
@@ -937,7 +941,7 @@ create_redirect_url_with_par_client_secret_jwt_request_object_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{issuer = Issuer} = Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -953,10 +957,12 @@ create_redirect_url_with_par_client_secret_jwt_request_object_test() ->
     },
 
     ParResponseData =
-        jsx:encode(#{
-            <<"request_uri">> => <<"urn:ietf:params:oauth:request_uri:par_response">>,
-            <<"expires_in">> => 60
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"request_uri">> => <<"urn:ietf:params:oauth:request_uri:par_response">>,
+                <<"expires_in">> => 60
+            })
+        ),
 
     ClientId = <<"client_id">>,
     ClientSecret = <<"at_least_32_character_client_secret">>,
@@ -1129,7 +1135,7 @@ private_key_jwt_fixture() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
     Configuration = Configuration0#oidcc_provider_configuration{
         token_endpoint_auth_methods_supported = [<<"private_key_jwt">>],

--- a/test/oidcc_client_context_test.erl
+++ b/test/oidcc_client_context_test.erl
@@ -272,7 +272,7 @@ client_context_fixture() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/fapi2-metadata.json"),
     {ok, #oidcc_provider_configuration{} = Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk-ed25519.pem"),
 

--- a/test/oidcc_client_registration_test.erl
+++ b/test/oidcc_client_registration_test.erl
@@ -16,7 +16,7 @@ register_test() ->
     {ok,
         #oidcc_provider_configuration{registration_endpoint = RegistrationEndpoint} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -29,10 +29,12 @@ register_test() ->
 
     ClientId = <<"client_id">>,
 
-    ResponseJson = jose:encode(#{
-        client_id => ClientId,
-        client_id_issued_at => erlang:system_time(second)
-    }),
+    ResponseJson = iolist_to_binary(
+        json:encode(#{
+            client_id => ClientId,
+            client_id_issued_at => erlang:system_time(second)
+        })
+    ),
 
     TelemetryRef =
         telemetry_test:attach_event_handlers(
@@ -60,7 +62,7 @@ register_test() ->
                     <<"require_auth_time">> := false,
                     <<"token_endpoint_auth_method">> := <<"client_secret_basic">>
                 },
-                jose:decode(Body)
+                json:decode(Body)
             ),
             {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], ResponseJson}}
         end,
@@ -103,7 +105,7 @@ registration_not_supported_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Configuration = Configuration0#oidcc_provider_configuration{registration_endpoint = undefined},
 
@@ -129,7 +131,7 @@ registration_invalid_response_test() ->
     {ok,
         #oidcc_provider_configuration{registration_endpoint = RegistrationEndpoint} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     RedirectUri = <<"https://example.com/oidcc/callback">>,
 
@@ -171,7 +173,7 @@ registration_invalid_response_test() ->
         ) ->
             RegistrationEndpoint = ReqEndpoint,
 
-            case jose:decode(Body) of
+            case json:decode(Body) of
                 #{<<"client_name">> := <<"jwt">>} ->
                     {ok, {
                         {"HTTP/1.1", 200, "OK"},
@@ -188,13 +190,17 @@ registration_invalid_response_test() ->
                     {ok, {
                         {"HTTP/1.1", 200, "OK"},
                         [{"content-type", "application/json"}],
-                        jose:encode(#{client_id => ClientId, client_id_issued_at => <<"invalid">>})
+                        iolist_to_binary(
+                            json:encode(#{
+                                client_id => ClientId, client_id_issued_at => <<"invalid">>
+                            })
+                        )
                     }};
                 #{<<"client_name">> := <<"invalid_client_id">>} ->
                     {ok, {
                         {"HTTP/1.1", 200, "OK"},
                         [{"content-type", "application/json"}],
-                        jose:encode(#{client_id => 7})
+                        iolist_to_binary(json:encode(#{client_id => 7}))
                     }}
             end
         end,

--- a/test/oidcc_logout_test.erl
+++ b/test/oidcc_logout_test.erl
@@ -12,7 +12,7 @@ initiate_url_test() ->
 
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ValidConfigString)
+        json:decode(ValidConfigString)
     ),
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 

--- a/test/oidcc_provider_configuration_test.erl
+++ b/test/oidcc_provider_configuration_test.erl
@@ -113,7 +113,7 @@ decode_google_test() ->
                         <<"https://oauth2.googleapis.com/device/code">>
                 }
         }},
-        oidcc_provider_configuration:decode_configuration(jose:decode(Configuration))
+        oidcc_provider_configuration:decode_configuration(json:decode(Configuration))
     ).
 
 check_validations_test() ->
@@ -587,7 +587,7 @@ document_overrides_quirk_test() ->
         {ok, #oidcc_provider_configuration{
             issuer = <<"https://example.com">>
         }},
-        oidcc_provider_configuration:decode_configuration(jose:decode(Configuration), #{
+        oidcc_provider_configuration:decode_configuration(json:decode(Configuration), #{
             quirks => #{document_overrides => #{<<"issuer">> => <<"https://example.com">>}}
         })
     ),
@@ -598,7 +598,7 @@ issuer_regex_quirk_test() ->
     {ok, Configuration} = file:read_file(PrivDir ++ "/test/fixtures/google-metadata.json"),
     RegexPattern = <<"^https://[a-z]+\\.google\\.com$">>,
 
-    Result = oidcc_provider_configuration:decode_configuration(jose:decode(Configuration), #{
+    Result = oidcc_provider_configuration:decode_configuration(json:decode(Configuration), #{
         quirks => #{issuer_regex => RegexPattern}
     }),
 
@@ -675,7 +675,7 @@ decode_fapi2_test() ->
                 <<"userinfo_endpoint">> := <<"https://my.provider/tls/userinfo">>
             }
         }},
-        oidcc_provider_configuration:decode_configuration(jose:decode(Configuration))
+        oidcc_provider_configuration:decode_configuration(json:decode(Configuration))
     ),
 
     ok.
@@ -683,7 +683,7 @@ decode_fapi2_test() ->
 google_merge_json(Merge) ->
     PrivDir = code:priv_dir(oidcc),
     {ok, ValidConfigString} = file:read_file(PrivDir ++ "/test/fixtures/google-metadata.json"),
-    Decoded = jose:decode(ValidConfigString),
+    Decoded = json:decode(ValidConfigString),
     maps:merge(Decoded, Merge).
 
 use_spec_defaults_in_implicit_configs_test() ->
@@ -695,7 +695,7 @@ use_spec_defaults_in_implicit_configs_test() ->
             issuer = <<"https://my.provider">>,
             token_endpoint_auth_methods_supported = [<<"client_secret_basic">>]
         }},
-        oidcc_provider_configuration:decode_configuration(jose:decode(Configuration))
+        oidcc_provider_configuration:decode_configuration(json:decode(Configuration))
     ),
 
     ok.

--- a/test/oidcc_provider_configuration_worker_SUITE.erl
+++ b/test/oidcc_provider_configuration_worker_SUITE.erl
@@ -179,15 +179,17 @@ refreshes_after_timeout(_Config) ->
     %% configured `fallback_expiry' (100 ms) -- this also exercises the
     %% cache-control parser regression covered by #371.
     Issuer = <<"https://example.com">>,
-    DiscoveryBody = jsx:encode(#{
-        issuer => Issuer,
-        jwks_uri => <<Issuer/binary, "/keys">>,
-        authorization_endpoint => <<Issuer/binary, "/authorize">>,
-        scopes_supported => [<<"openid">>],
-        response_types_supported => [<<"code">>],
-        subject_types_supported => [<<"public">>],
-        id_token_signing_alg_values_supported => [<<"RS256">>]
-    }),
+    DiscoveryBody = iolist_to_binary(
+        json:encode(#{
+            issuer => Issuer,
+            jwks_uri => <<Issuer/binary, "/keys">>,
+            authorization_endpoint => <<Issuer/binary, "/authorize">>,
+            scopes_supported => [<<"openid">>],
+            response_types_supported => [<<"code">>],
+            subject_types_supported => [<<"public">>],
+            id_token_signing_alg_values_supported => [<<"RS256">>]
+        })
+    ),
     DiscoveryHeaders = [
         {"content-type", "application/json"},
         {"cache-control", "max-age=0, no-store"}
@@ -210,7 +212,11 @@ refreshes_after_timeout(_Config) ->
                 _Opts,
                 _Profile
             ) ->
-                {ok, {{"HTTP/1.1", 200, "OK"}, JwksHeaders, jsx:encode(#{keys => []})}}
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    JwksHeaders,
+                    iolist_to_binary(json:encode(#{keys => []}))
+                }}
         end,
     ok = meck:new(httpc, [no_link]),
     ok = meck:expect(httpc, request, HttpFun),

--- a/test/oidcc_provider_configuration_worker_test.erl
+++ b/test/oidcc_provider_configuration_worker_test.erl
@@ -126,15 +126,17 @@ refreshes_in_background_with_adapter_test() ->
 %% expiry — including the literal `max-age=0' — flows through the
 %% backoff/retry path and the worker keeps running.
 survives_cache_control_max_age_zero_test() ->
-    DiscoveryBody = jsx:encode(#{
-        issuer => <<"https://example.com">>,
-        jwks_uri => <<"https://example.com/keys">>,
-        authorization_endpoint => <<"https://example.com/authorize">>,
-        scopes_supported => [<<"openid">>],
-        response_types_supported => [<<"code">>],
-        subject_types_supported => [<<"public">>],
-        id_token_signing_alg_values_supported => [<<"RS256">>]
-    }),
+    DiscoveryBody = iolist_to_binary(
+        json:encode(#{
+            issuer => <<"https://example.com">>,
+            jwks_uri => <<"https://example.com/keys">>,
+            authorization_endpoint => <<"https://example.com/authorize">>,
+            scopes_supported => [<<"openid">>],
+            response_types_supported => [<<"code">>],
+            subject_types_supported => [<<"public">>],
+            id_token_signing_alg_values_supported => [<<"RS256">>]
+        })
+    ),
     HttpFun =
         fun
             (
@@ -165,7 +167,7 @@ survives_cache_control_max_age_zero_test() ->
                         {"content-type", "application/json"},
                         {"cache-control", "max-age=0, no-store"}
                     ],
-                    jsx:encode(#{keys => []})
+                    iolist_to_binary(json:encode(#{keys => []}))
                 }}
         end,
 
@@ -207,15 +209,17 @@ accepts_generic_plus_json_content_type_test() ->
                 {ok, {
                     {"HTTP/1.1", 200, "OK"},
                     [{"content-type", "application/json"}],
-                    jsx:encode(#{
-                        issuer => <<"https://example.com">>,
-                        jwks_uri => <<"https://example.com/keys">>,
-                        authorization_endpoint => <<"https://example.com/authorize">>,
-                        scopes_supported => [<<"openid">>],
-                        response_types_supported => [<<"code">>],
-                        subject_types_supported => [<<"public">>],
-                        id_token_signing_alg_values_supported => [<<"RS256">>]
-                    })
+                    iolist_to_binary(
+                        json:encode(#{
+                            issuer => <<"https://example.com">>,
+                            jwks_uri => <<"https://example.com/keys">>,
+                            authorization_endpoint => <<"https://example.com/authorize">>,
+                            scopes_supported => [<<"openid">>],
+                            response_types_supported => [<<"code">>],
+                            subject_types_supported => [<<"public">>],
+                            id_token_signing_alg_values_supported => [<<"RS256">>]
+                        })
+                    )
                 }};
             (
                 get,
@@ -227,7 +231,7 @@ accepts_generic_plus_json_content_type_test() ->
                 {ok, {
                     {"HTTP/1.1", 200, "OK"},
                     [{"content-type", "application/vnd.example+json; charset=utf-8"}],
-                    jsx:encode(#{keys => []})
+                    iolist_to_binary(json:encode(#{keys => []}))
                 }}
         end,
 
@@ -384,15 +388,17 @@ provider_adapter(TestPid, AdapterState) ->
                 {ok, {
                     {"HTTP/1.1", 200, "OK"},
                     [{"content-type", "application/json"} | AdditionalHeaders],
-                    jsx:encode(#{
-                        issuer => <<"https://example.com">>,
-                        jwks_uri => <<"https://example.com/keys">>,
-                        authorization_endpoint => <<"https://example.com/authorize">>,
-                        scopes_supported => [<<"openid">>],
-                        response_types_supported => [<<"code">>],
-                        subject_types_supported => [<<"public">>],
-                        id_token_signing_alg_values_supported => [<<"RS256">>]
-                    })
+                    iolist_to_binary(
+                        json:encode(#{
+                            issuer => <<"https://example.com">>,
+                            jwks_uri => <<"https://example.com/keys">>,
+                            authorization_endpoint => <<"https://example.com/authorize">>,
+                            scopes_supported => [<<"openid">>],
+                            response_types_supported => [<<"code">>],
+                            subject_types_supported => [<<"public">>],
+                            id_token_signing_alg_values_supported => [<<"RS256">>]
+                        })
+                    )
                 }};
             (
                 get,
@@ -406,7 +412,7 @@ provider_adapter(TestPid, AdapterState) ->
                 {ok, {
                     {"HTTP/1.1", 200, "OK"},
                     [{"content-type", "application/json"} | AdditionalHeaders],
-                    jsx:encode(#{keys => []})
+                    iolist_to_binary(json:encode(#{keys => []}))
                 }}
         end,
     {oidcc_http_adapter_test, #{request => HttpFun}}.

--- a/test/oidcc_token_SUITE.erl
+++ b/test/oidcc_token_SUITE.erl
@@ -50,7 +50,7 @@ retrieves_jwt_profile_token(_Config) ->
     PrivDir = code:priv_dir(oidcc),
 
     {ok, KeyJson} = file:read_file(PrivDir ++ "/test/fixtures/zitadel-jwt-profile.json"),
-    KeyMap = jose:decode(KeyJson),
+    KeyMap = json:decode(KeyJson),
     Key = jose_jwk:from_pem(maps:get(<<"key">>, KeyMap)),
 
     application:set_env(oidcc, max_clock_skew, 10),
@@ -97,7 +97,7 @@ retrieves_client_credentials_token(_Config) ->
     #{
         <<"clientId">> := ZitadelClientCredentialsClientId,
         <<"clientSecret">> := ZitadelClientCredentialsClientSecret
-    } = jose:decode(ZitadelClientCredentialsJson),
+    } = json:decode(ZitadelClientCredentialsJson),
 
     {ok, ZitadelClientContext} = oidcc_client_context:from_configuration_worker(
         ZitadelConfigurationPid,
@@ -136,7 +136,7 @@ validates_access_token(_Config) ->
     #{
         <<"clientId">> := ZitadelClientCredentialsClientId,
         <<"clientSecret">> := ZitadelClientCredentialsClientSecret
-    } = jose:decode(ZitadelClientCredentialsJson),
+    } = json:decode(ZitadelClientCredentialsJson),
 
     {ok, ZitadelClientContext} = oidcc_client_context:from_configuration_worker(
         ZitadelConfigurationPid,

--- a/test/oidcc_token_introspection_test.erl
+++ b/test/oidcc_token_introspection_test.erl
@@ -15,7 +15,7 @@ introspect_test() ->
     {ok,
         #oidcc_provider_configuration{introspection_endpoint = IntrospectionEndpoint} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -37,11 +37,13 @@ introspect_test() ->
             {ok, {
                 {"HTTP/1.1", 200, "OK"},
                 [{"content-type", "application/json"}],
-                jsx:encode(#{
-                    <<"active">> => true,
-                    <<"client_id">> => ClientId,
-                    <<"extra">> => <<"value">>
-                })
+                iolist_to_binary(
+                    json:encode(#{
+                        <<"active">> => true,
+                        <<"client_id">> => ClientId,
+                        <<"extra">> => <<"value">>
+                    })
+                )
             }}
         end,
     RequestOpts = #{
@@ -86,7 +88,7 @@ introspect_inactive_test() ->
     {ok,
         #oidcc_provider_configuration{introspection_endpoint = IntrospectionEndpoint} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -129,7 +131,7 @@ introspection_not_supported_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Configuration = Configuration0#oidcc_provider_configuration{
         introspection_endpoint = undefined
@@ -161,7 +163,7 @@ introspection_invalid_client_id_test() ->
     {ok,
         #oidcc_provider_configuration{introspection_endpoint = IntrospectionEndpoint} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -211,7 +213,7 @@ introspection_issuer_client_id_test() ->
             issuer = Issuer
         } =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 

--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -30,7 +30,7 @@ retrieve_none_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
         Configuration = Configuration0#oidcc_provider_configuration{
@@ -63,13 +63,15 @@ retrieve_none_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"expires_in">> => <<"3600">>
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"expires_in">> => <<"3600">>
+            })
+        ),
 
     ClientContext = oidcc_client_context:from_manual(Configuration, JwkSet, ClientId, ClientSecret),
 
@@ -146,7 +148,7 @@ retrieve_rs256_with_rotation_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -188,13 +190,15 @@ retrieve_rs256_with_rotation_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientContext = oidcc_client_context:from_manual(
         Configuration, JwkBeforeRefresh, ClientId, ClientSecret
@@ -264,7 +268,7 @@ retrieve_hs256_test() ->
     {ok,
         #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     ClientId = <<"client_id">>,
     ClientSecret = <<"at_least_32_character_client_secret">>,
@@ -291,13 +295,15 @@ retrieve_hs256_test() ->
     OtherJwk = jose_jwk:from_file(PrivDir ++ "/test/fixtures/openid-certification-jwks.json"),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientContext = oidcc_client_context:from_manual(
         Configuration, OtherJwk, ClientId, ClientSecret
@@ -346,7 +352,7 @@ retrieve_hs256_with_max_clock_skew_test() ->
     {ok,
         #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     ClientId = <<"client_id">>,
     ClientSecret = <<"at_least_32_character_client_secret">>,
@@ -374,13 +380,15 @@ retrieve_hs256_with_max_clock_skew_test() ->
     OtherJwk = jose_jwk:from_file(PrivDir ++ "/test/fixtures/openid-certification-jwks.json"),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientContext = oidcc_client_context:from_manual(
         Configuration, OtherJwk, ClientId, ClientSecret
@@ -440,7 +448,7 @@ auth_method_client_secret_jwt_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -477,13 +485,15 @@ auth_method_client_secret_jwt_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientContext = oidcc_client_context:from_manual(Configuration, Jwk, ClientId, ClientSecret),
 
@@ -566,7 +576,7 @@ auth_method_client_secret_jwt_with_max_clock_skew_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -603,13 +613,15 @@ auth_method_client_secret_jwt_with_max_clock_skew_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientContext = oidcc_client_context:from_manual(Configuration, Jwk, ClientId, ClientSecret),
 
@@ -666,7 +678,7 @@ auth_method_private_key_jwt_no_supported_alg_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -703,13 +715,15 @@ auth_method_private_key_jwt_no_supported_alg_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientContext = oidcc_client_context:from_manual(Configuration, Jwk, ClientId, ClientSecret),
 
@@ -767,7 +781,7 @@ auth_method_private_key_jwt_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -802,13 +816,15 @@ auth_method_private_key_jwt_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientJwk0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
     ClientJwk = ClientJwk0#jose_jwk{
@@ -907,7 +923,7 @@ auth_method_private_key_jwt_override_claims_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -942,13 +958,15 @@ auth_method_private_key_jwt_override_claims_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientJwk0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
     ClientJwk = ClientJwk0#jose_jwk{
@@ -1052,7 +1070,7 @@ auth_method_private_key_jwt_with_dpop_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -1088,13 +1106,15 @@ auth_method_private_key_jwt_with_dpop_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientJwk0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
     ClientJwk = ClientJwk0#jose_jwk{
@@ -1233,7 +1253,7 @@ auth_method_private_key_jwt_with_dpop_and_nonce_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -1270,19 +1290,23 @@ auth_method_private_key_jwt_with_dpop_and_nonce_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
-    DpopNonceError = jsx:encode(#{
-        <<"error">> => <<"use_dpop_nonce">>,
-        <<"error_description">> =>
-            <<"Authorization server requires nonce in DPoP proof">>
-    }),
+    DpopNonceError = iolist_to_binary(
+        json:encode(#{
+            <<"error">> => <<"use_dpop_nonce">>,
+            <<"error_description">> =>
+                <<"Authorization server requires nonce in DPoP proof">>
+        })
+    ),
 
     ClientJwk0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
     ClientJwk = ClientJwk0#jose_jwk{
@@ -1439,7 +1463,7 @@ auth_method_private_key_jwt_with_invalid_dpop_nonce_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -1455,11 +1479,13 @@ auth_method_private_key_jwt_with_invalid_dpop_nonce_test() ->
     DpopNonce = <<"dpop_nonce">>,
     Jwk = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
-    DpopNonceError = jsx:encode(#{
-        <<"error">> => <<"use_dpop_nonce">>,
-        <<"error_description">> =>
-            <<"Authorization server requires nonce in DPoP proof">>
-    }),
+    DpopNonceError = iolist_to_binary(
+        json:encode(#{
+            <<"error">> => <<"use_dpop_nonce">>,
+            <<"error_description">> =>
+                <<"Authorization server requires nonce in DPoP proof">>
+        })
+    ),
 
     ClientJwk0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
     ClientJwk = ClientJwk0#jose_jwk{
@@ -1512,7 +1538,7 @@ auth_method_client_secret_jwt_no_alg_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     Configuration = Configuration0#oidcc_provider_configuration{
@@ -1549,7 +1575,7 @@ preferred_auth_methods_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
@@ -1586,13 +1612,15 @@ preferred_auth_methods_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>,
-            <<"refresh_token">> => RefreshToken
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>,
+                <<"refresh_token">> => RefreshToken
+            })
+        ),
 
     ClientContext = oidcc_client_context:from_manual(Configuration, Jwk, ClientId, ClientSecret),
 
@@ -1649,7 +1677,7 @@ authorization_headers_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     SigningAlg = [<<"RS256">>],
@@ -1791,12 +1819,14 @@ trusted_audiences_test() ->
         ),
 
     TokenData =
-        jsx:encode(#{
-            <<"access_token">> => AccessToken,
-            <<"token_type">> => <<"Bearer">>,
-            <<"id_token">> => Token,
-            <<"scope">> => <<"profile openid">>
-        }),
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>
+            })
+        ),
 
     ok = meck:new(httpc, [no_link]),
     HttpFun =
@@ -2151,7 +2181,7 @@ validate_id_token_rotation_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{issuer = Issuer} = Configuration} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     ClientId = <<"client_id">>,
@@ -2343,7 +2373,7 @@ client_context_fapi2_fixture() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/fapi2-metadata.json"),
     {ok, Configuration} = oidcc_provider_configuration:decode_configuration(
-        jose:decode(ConfigurationBinary)
+        json:decode(ConfigurationBinary)
     ),
 
     Jwk0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),

--- a/test/oidcc_userinfo_test.erl
+++ b/test/oidcc_userinfo_test.erl
@@ -15,7 +15,7 @@ json_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint} = Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -108,7 +108,7 @@ jwt_test() ->
     {ok,
         #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint, issuer = Issuer} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     JwkBeforeRefresh0 = jose_jwk:generate_key(16),
     JwkBeforeRefresh = JwkBeforeRefresh0#jose_jwk{fields = #{<<"kid">> => <<"kid1">>}},
@@ -217,7 +217,7 @@ jwt_encrypted_not_signed_test() ->
     {ok,
         #oidcc_provider_configuration{} =
             Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwk = jose_jwk:generate_key({rsa, 1024}),
 
@@ -285,7 +285,7 @@ distributed_claims_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint} = Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -320,23 +320,25 @@ distributed_claims_test() ->
                     {ok, {
                         {"HTTP/1.1", 200, "OK"},
                         [{"content-type", "application/json"}],
-                        jsx:encode(#{
-                            <<"sub">> => Sub,
-                            <<"_claim_names">> => #{
-                                <<"first_name">> => <<"remote">>,
-                                <<"last_name">> => <<"local">>
-                            },
-                            <<"_claim_sources">> => #{
-                                <<"remote">> => #{
-                                    <<"endpoint">> =>
-                                        <<"https://my.provider/distributed-claim">>,
-                                    <<"access_token">> => <<"acces_token">>
+                        iolist_to_binary(
+                            json:encode(#{
+                                <<"sub">> => Sub,
+                                <<"_claim_names">> => #{
+                                    <<"first_name">> => <<"remote">>,
+                                    <<"last_name">> => <<"local">>
                                 },
-                                <<"local">> => #{
-                                    <<"JWT">> => LocalToken
+                                <<"_claim_sources">> => #{
+                                    <<"remote">> => #{
+                                        <<"endpoint">> =>
+                                            <<"https://my.provider/distributed-claim">>,
+                                        <<"access_token">> => <<"acces_token">>
+                                    },
+                                    <<"local">> => #{
+                                        <<"JWT">> => LocalToken
+                                    }
                                 }
-                            }
-                        })
+                            })
+                        )
                     }};
                 <<"https://my.provider/distributed-claim">> ->
                     {ok, {
@@ -384,7 +386,7 @@ distributed_claims_invalid_json_resp_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint} = Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -466,7 +468,7 @@ distributed_claims_http_error_resp_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint} = Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -548,7 +550,7 @@ distributed_claims_invalid_source_mapping_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint} = Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 
@@ -619,7 +621,7 @@ dpop_proof_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint} = Configuration0} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Configuration = Configuration0#oidcc_provider_configuration{
         dpop_signing_alg_values_supported = [<<"RS256">>]
@@ -725,7 +727,7 @@ dpop_proof_case_insensitive_token_type_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint} = Configuration0} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Configuration = Configuration0#oidcc_provider_configuration{
         dpop_signing_alg_values_supported = [<<"RS256">>]
@@ -789,7 +791,7 @@ dpop_proof_with_nonce_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, #oidcc_provider_configuration{userinfo_endpoint = UserInfoEndpoint} = Configuration0} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Configuration = Configuration0#oidcc_provider_configuration{
         dpop_signing_alg_values_supported = [<<"RS256">>]
@@ -815,11 +817,13 @@ dpop_proof_with_nonce_test() ->
         #{mode => urlsafe, padding => false}
     ),
     DpopNonce = <<"dpop_nonce">>,
-    DpopNonceError = jsx:encode(#{
-        <<"error">> => <<"use_dpop_nonce">>,
-        <<"error_description">> =>
-            <<"Authorization server requires nonce in DPoP proof">>
-    }),
+    DpopNonceError = iolist_to_binary(
+        json:encode(#{
+            <<"error">> => <<"use_dpop_nonce">>,
+            <<"error_description">> =>
+                <<"Authorization server requires nonce in DPoP proof">>
+        })
+    ),
 
     HttpFun =
         fun(get, {Url, Header}, _HttpOpts, _Opts, _Profile) ->
@@ -914,7 +918,7 @@ dpop_proof_with_invalid_nonce_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration0} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Configuration = Configuration0#oidcc_provider_configuration{
         dpop_signing_alg_values_supported = [<<"RS256">>]
@@ -935,11 +939,13 @@ dpop_proof_with_invalid_nonce_test() ->
     Sub = <<"123456">>,
     AccessToken = <<"opensesame">>,
     DpopNonce = <<"dpop_nonce">>,
-    DpopNonceError = jsx:encode(#{
-        <<"error">> => <<"use_dpop_nonce">>,
-        <<"error_description">> =>
-            <<"Authorization server requires nonce in DPoP proof">>
-    }),
+    DpopNonceError = iolist_to_binary(
+        json:encode(#{
+            <<"error">> => <<"use_dpop_nonce">>,
+            <<"error_description">> =>
+                <<"Authorization server requires nonce in DPoP proof">>
+        })
+    ),
 
     HttpFun =
         fun(get, _UrlHeader, _HttpOpts, _Opts, _Profile) ->
@@ -978,7 +984,7 @@ retrieve_no_access_token_test() ->
 
     {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
     {ok, Configuration} =
-        oidcc_provider_configuration:decode_configuration(jose:decode(ConfigurationBinary)),
+        oidcc_provider_configuration:decode_configuration(json:decode(ConfigurationBinary)),
 
     Jwks = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
 


### PR DESCRIPTION
With OTP 27 as the minimum supported version, the `json` module is always available. Replace `jose:decode/1` and `jose:encode/1` with `json:decode/1` and `json:encode/1`, and drop the test-only `jsx` dependency in favour of `json:encode/1`.

`jose` already delegated to `jose_json_otp` (the OTP `json` module) on OTP 27+, so decoding behaviour is unchanged. `json:encode/1` returns iodata rather than a binary, so call sites are wrapped in `iolist_to_binary/1` to keep the `binary()` contracts of `oidcc_client_registration:encode/1` and `oidcc_http_adapter:response/0`.

`jose` remains a dependency for JWT/JWK handling.
