### PR TITLE
Return an error instead of raising on malformed JSON

### DIFF
--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -29,6 +29,7 @@
     {http_error, StatusCode :: non_neg_integer(), HttpBodyResult :: binary() | map()}
     | {use_dpop_nonce, Nonce :: binary(), HttpBodyResult :: binary() | map()}
     | invalid_content_type
+    | {invalid_json, Reason :: term()}
     | httpc_error().
 
 -doc "Transport error. The default adapter returns errors documented by `httpc:request/5`.".
@@ -142,7 +143,12 @@ extract_successful_response({{_HttpVersion, Status, _HttpStatusName}, Headers, H
 ->
     case fetch_content_type(Headers) of
         json ->
-            {ok, {json, json:decode(HttpBodyResult)}};
+            case decode_json(HttpBodyResult) of
+                {ok, Json} ->
+                    {ok, {json, Json}};
+                {error, Reason} ->
+                    {error, {invalid_json, Reason}}
+            end;
         jwt ->
             {ok, {jwt, HttpBodyResult}};
         unknown ->
@@ -152,7 +158,13 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
     Body =
         case fetch_content_type(Headers) of
             json ->
-                json:decode(HttpBodyResult);
+                %% A provider that cannot format its own error document must not
+                %% mask the status code, which is the actual failure. Hand back
+                %% the undecoded body, exactly as the `unknown' branch does.
+                case decode_json(HttpBodyResult) of
+                    {ok, Json} -> Json;
+                    {error, _Reason} -> HttpBodyResult
+                end;
             jwt ->
                 HttpBodyResult;
             unknown ->
@@ -163,6 +175,24 @@ extract_successful_response({{_HttpVersion, StatusCode, _HttpStatusName}, Header
             {error, {use_dpop_nonce, iolist_to_binary(DpopNonce), Body}};
         _ ->
             {error, {http_error, StatusCode, Body}}
+    end.
+
+%% `json:decode/1' raises on malformed input rather than returning an error.
+%% A provider is free to serve a broken document under a JSON content type, and
+%% that must not take the calling process down with it.
+%%
+%% The guard keeps that narrow. A body that is not a binary means the adapter
+%% broke its contract, most often by dropping the `body_format' request option
+%% on the way to `httpc:request/5' and getting a string back. That is the
+%% caller's bug, not the provider's, so it keeps crashing where the stack trace
+%% still points at it instead of being reported as a malformed document.
+-spec decode_json(Body :: binary()) -> {ok, term()} | {error, term()}.
+decode_json(Body) when is_binary(Body) ->
+    try
+        {ok, json:decode(Body)}
+    catch
+        error:Reason ->
+            {error, Reason}
     end.
 
 -spec fetch_content_type(Headers) -> json | jwt | unknown when

--- a/test/oidcc_http_adapter_test.erl
+++ b/test/oidcc_http_adapter_test.erl
@@ -106,6 +106,131 @@ adapter_error_normalization_test() ->
         )
     ).
 
+adapter_invalid_json_response_test() ->
+    TruncatedFun =
+        fun(
+            get,
+            {<<"https://example.com/.well-known/openid-configuration">>, []},
+            _HttpOptions,
+            _RequestOptions,
+            _Config
+        ) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/json"}],
+                <<"{\"issuer\": ">>
+            }}
+        end,
+    ?assertMatch(
+        {error, {invalid_json, _}},
+        oidcc_http_util:request(
+            get,
+            {<<"https://example.com/.well-known/openid-configuration">>, []},
+            telemetry_opts(adapter_invalid_json),
+            #{http_adapter => {?MODULE, #{request => TruncatedFun}}}
+        )
+    ),
+
+    TrailingGarbageFun =
+        fun(post, _Request, _HttpOptions, _RequestOptions, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 201, "Created"},
+                [{"content-type", "application/jwk-set+json"}],
+                <<"{} not json">>
+            }}
+        end,
+    ?assertMatch(
+        {error, {invalid_json, _}},
+        oidcc_http_util:request(
+            post,
+            {<<"https://example.com/register">>, [], "application/json", <<"{}">>},
+            telemetry_opts(adapter_invalid_json_trailing),
+            #{http_adapter => {?MODULE, #{request => TrailingGarbageFun}}}
+        )
+    ).
+
+%% A malformed body on a non-2xx response must not hide the status code, which
+%% is the actual failure, so the undecoded body is handed back instead.
+adapter_invalid_json_error_response_test() ->
+    Body = <<"{\"error\": ">>,
+    ErrorFun =
+        fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 500, "Internal Server Error"},
+                [{"content-type", "application/json"}],
+                Body
+            }}
+        end,
+    ?assertEqual(
+        {error, {http_error, 500, Body}},
+        oidcc_http_util:request(
+            get,
+            {<<"https://example.com">>, []},
+            telemetry_opts(adapter_invalid_json_error),
+            #{http_adapter => {?MODULE, #{request => ErrorFun}}}
+        )
+    ),
+
+    DpopNonceFun =
+        fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 400, "Bad Request"},
+                [{"content-type", "application/json"}, {"dpop-nonce", <<"nonce-value">>}],
+                Body
+            }}
+        end,
+    ?assertEqual(
+        {error, {use_dpop_nonce, <<"nonce-value">>, Body}},
+        oidcc_http_util:request(
+            get,
+            {<<"https://example.com">>, []},
+            telemetry_opts(adapter_invalid_json_dpop_nonce),
+            #{http_adapter => {?MODULE, #{request => DpopNonceFun}}}
+        )
+    ).
+
+%% An adapter returning a non-binary body has broken its contract. That is not a
+%% malformed document, and reporting it as one would hide the caller's bug and
+%% put a value outside `error()' into `{http_error, _, Body}'.
+adapter_non_binary_body_still_crashes_test() ->
+    NonBinaryFun =
+        fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/json"}],
+                "{\"valid\": true}"
+            }}
+        end,
+
+    ?assertError(
+        function_clause,
+        oidcc_http_util:request(
+            get,
+            {<<"https://example.com">>, []},
+            telemetry_opts(adapter_non_binary_body),
+            #{http_adapter => {?MODULE, #{request => NonBinaryFun}}}
+        )
+    ),
+
+    ErrorStatusFun =
+        fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 500, "Internal Server Error"},
+                [{"content-type", "application/json"}],
+                "{\"error\": \"x\"}"
+            }}
+        end,
+
+    ?assertError(
+        function_clause,
+        oidcc_http_util:request(
+            get,
+            {<<"https://example.com">>, []},
+            telemetry_opts(adapter_non_binary_error_body),
+            #{http_adapter => {?MODULE, #{request => ErrorStatusFun}}}
+        )
+    ).
+
 adapter_telemetry_test() ->
     {ok, _} = application:ensure_all_started(telemetry),
     Topic = [oidcc, adapter_telemetry],
@@ -178,6 +303,31 @@ adapter_telemetry_test() ->
             Topic,
             ProtocolFailureMetadata,
             ProtocolFailureMetadata#{error => ProtocolFailure}
+        ),
+
+        InvalidJsonMetadata = #{issuer => <<"https://invalid-json.example">>},
+        InvalidJsonFun =
+            fun(_Method, _Request, _HttpOptions, _RequestOptions, _Config) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [{"content-type", "application/json"}],
+                    <<"{\"issuer\": ">>
+                }}
+            end,
+        {error, InvalidJson} =
+            oidcc_http_util:request(
+                get,
+                {<<"https://invalid-json.example">>, []},
+                #{topic => Topic, extra_meta => InvalidJsonMetadata},
+                #{http_adapter => {?MODULE, #{request => InvalidJsonFun}}}
+            ),
+        ?assertMatch({invalid_json, _}, InvalidJson),
+        %% A malformed body is reported through the `stop' event like any other
+        %% error, rather than raising and emitting `exception'.
+        assert_span(
+            Topic,
+            InvalidJsonMetadata,
+            InvalidJsonMetadata#{error => InvalidJson}
         )
     after
         telemetry:detach(HandlerId)

--- a/test/oidcc_provider_configuration_test.erl
+++ b/test/oidcc_provider_configuration_test.erl
@@ -612,6 +612,36 @@ issuer_regex_quirk_test() ->
 
     ok.
 
+invalid_json_configuration_test() ->
+    HttpFun =
+        fun(get, _Request, _HttpOpts, _Opts, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/json"}],
+                <<"{\"issuer\": ">>
+            }}
+        end,
+
+    ?assertMatch(
+        {error, {invalid_json, _}},
+        oidcc_provider_configuration:load_configuration(<<"https://example.com">>, #{
+            request_opts => #{
+                http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}
+            }
+        })
+    ),
+
+    ?assertMatch(
+        {error, {invalid_json, _}},
+        oidcc_provider_configuration:load_jwks(<<"https://example.com/keys">>, #{
+            request_opts => #{
+                http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}
+            }
+        })
+    ),
+
+    ok.
+
 uri_concatenation_test() ->
     ok = meck:new(httpc, [no_link]),
     HttpFun =


### PR DESCRIPTION
`json:decode/1` raises rather than returning an error, and
`oidcc_http_util:extract_successful_response/1` called it unguarded in both of its
clauses. A provider that serves a syntactically malformed document under a JSON content
type takes the calling process down instead of returning `{error, _}`, so every caller
has to wrap oidcc in a try/catch to be safe.

To reproduce, point an adapter at
`{ok, {{"HTTP/1.1", 200, ""}, [{"content-type", "application/json"}], <<"{\"issuer\": ">>}}`
and call `oidcc_provider_configuration:load_configuration/2`. It dies with
`error:unexpected_end`.

The 200/201 clause now returns `{error, {invalid_json, Reason}}`, a new member of
`oidcc_http_util:error()`. Every module consuming that union includes it by reference
rather than re-listing its members, so nothing downstream changes.

The non-2xx clause hands back the undecoded body instead. The status code is the real
failure there, and `{http_error, Status, Body}` already permits a binary body, so a
provider that can't format its own error document no longer masks its own 500. That's
what the unknown content type branch already did.

The catch is narrow on purpose: `decode_json/1` is guarded on `is_binary(Body)`. A
non-binary body means the adapter broke its contract, most often by dropping the
`body_format` option on the way to `httpc:request/5`, so it keeps crashing with the
stack trace pointing at the adapter instead of being reported as a malformed document.
Reporting it as `invalid_json` would also put a value outside `error()` into
`{http_error, _, Body}` on the non-2xx path.

This covers syntax only. A document that parses but isn't a JSON object, `null` for
instance, is a separate problem handled where the document is consumed.

One behaviour change: a malformed body used to raise inside `telemetry:span/3` and emit
an `exception` event. It now emits `stop` with `error` in the metadata, like every other
error path. `test/oidcc_http_adapter_test.erl` asserts that.
