### PR TITLE
Allow overriding the oidcc_plug version for certification

### DIFF
--- a/.github/workflows/manual_certification.yml
+++ b/.github/workflows/manual_certification.yml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Erlang Ecosystem Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+on:
+  workflow_dispatch:
+    inputs:
+      oidcc_plug_version:
+        description: >-
+          `oidcc_plug` version to certify against. Either "main" for the
+          `main` branch of `erlef/oidcc_plug` or a Hex version requirement
+          such as "~> 0.5.0". Defaults to the requirement declared in
+          `certification/implementation_plug.exs`.
+        required: false
+        type: string
+        default: ""
+
+name: "Manual Certification"
+
+permissions:
+  contents: read
+
+jobs:
+  certification:
+    name: "Certification"
+
+    permissions:
+      contents: read
+
+    uses: ./.github/workflows/part_certification.yml
+    with:
+      oidcc_plug_version: ${{ inputs.oidcc_plug_version }}
+    secrets:
+      OID_CERTIFICATION_API_TOKEN: ${{ secrets.OID_CERTIFICATION_API_TOKEN }}

--- a/.github/workflows/part_certification.yml
+++ b/.github/workflows/part_certification.yml
@@ -3,6 +3,16 @@
 
 on:
   workflow_call:
+    inputs:
+      oidcc_plug_version:
+        description: >-
+          `oidcc_plug` version to certify against. Either "main" for the
+          `main` branch of `erlef/oidcc_plug` or a Hex version requirement
+          such as "~> 0.5.0". Defaults to the requirement declared in
+          `certification/implementation_plug.exs`.
+        required: false
+        type: string
+        default: ""
     secrets:
       OID_CERTIFICATION_API_TOKEN:
         description: "OpenID Certification API Token"
@@ -42,6 +52,8 @@ jobs:
 
       # Prime Mix.install to prevent Mix Compile Locks
       - run: 'echo "" | certification/implementation_plug.exs'
+        env:
+          OIDCC_PLUG_VERSION: ${{ inputs.oidcc_plug_version }}
 
       - uses: erlef/oid_certo@e47ec90093332ecc3c11d0bdec85d5306c778c29 # v0.1.0-beta.4
         with:
@@ -52,6 +64,7 @@ jobs:
           api-token: ${{ secrets.OID_CERTIFICATION_API_TOKEN }}
         env:
           TMP: ${{ runner.temp }}
+          OIDCC_PLUG_VERSION: ${{ inputs.oidcc_plug_version }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/certification/implementation_plug.exs
+++ b/certification/implementation_plug.exs
@@ -16,10 +16,40 @@ handler_config =
 Mix.start()
 Mix.shell(Mix.Shell.Quiet)
 
+default_oidcc_plug_version = "~> 0.5.0"
+
+# Allows conformance testing against an unreleased `oidcc_plug`.
+#
+# * unset / `""` - the default version requirement above
+# * `"main"` - the `main` branch of `erlef/oidcc_plug`
+# * anything else - a Hex version requirement (`"~> 0.3.1"`, `"0.3.1"`, ...)
+oidcc_plug_dep =
+  case "OIDCC_PLUG_VERSION" |> System.get_env(default_oidcc_plug_version) |> String.trim() do
+    "" ->
+      {:oidcc_plug, default_oidcc_plug_version}
+
+    "main" ->
+      {:oidcc_plug, github: "erlef/oidcc_plug", branch: "main"}
+
+    version ->
+      case Version.parse_requirement(version) do
+        {:ok, _requirement} ->
+          {:oidcc_plug, version}
+
+        :error ->
+          raise """
+          Invalid OIDCC_PLUG_VERSION: #{inspect(version)}
+
+          Expected "main" (erlef/oidcc_plug main branch) or a Hex version \
+          requirement such as ">= 0.0.0" or "~> 0.5.0".\
+          """
+      end
+  end
+
 Mix.install([
   {:bandit, "~> 1.0"},
   {:oidcc, path: Path.dirname(__DIR__), override: true},
-  {:oidcc_plug, "~> 0.3.1"},
+  oidcc_plug_dep,
   {:jason, "~> 1.4"},
   {:phoenix_live_view, "~> 1.0"},
   {:phoenix, "~> 1.7"}


### PR DESCRIPTION
The conformance implementation pinned `oidcc_plug` to a fixed Hex requirement, so there was no way to certify against an unreleased version.

`OIDCC_PLUG_VERSION` now selects the dependency in `certification/implementation_plug.exs`:

| Value | Resolves to |
| --- | --- |
| unset / empty | the default requirement declared in the script |
| `main` | `github: "erlef/oidcc_plug", branch: "main"` |
| anything else | a Hex version requirement, e.g. `~> 0.5.0` |

Invalid values raise with an explanatory error rather than being silently treated as a branch name.

`part_certification.yml` takes the version as an optional input and passes it to both the `Mix.install` priming step and the certification run (the latter re-resolves dependencies, so it needs it too). The new `manual_certification.yml` exposes it via `workflow_dispatch`, so a pre-release conformance check can be triggered on `main` without running the rest of the main branch pipeline.

**Note:** this also bumps the default requirement from `~> 0.3.1` to `~> 0.5.0`, which changes what gets certified on every push to `main`, not only manual runs.