### PR TITLE
Return the provider document from the configuration loaders

### DIFF
--- a/lib/oidcc/provider_configuration.ex
+++ b/lib/oidcc/provider_configuration.ex
@@ -152,6 +152,42 @@ defmodule Oidcc.ProviderConfiguration do
   end
 
   @doc """
+  Load OpenID Configuration, keeping the document the provider served
+
+  Same as `load_configuration/2`, but additionally returns the decoded JSON
+  document. The struct cannot be re-encoded losslessly - `extra_fields` holds
+  only the keys the decoder did not recognize, every other key is coerced into a
+  typed field, and `issuer_regex` is not an OpenID Discovery field at all - so
+  callers that persist provider metadata need the document itself.
+
+  ## Examples
+
+      iex> {:ok, {
+      ...>   %ProviderConfiguration{issuer: "https://accounts.google.com"},
+      ...>   _expiry,
+      ...>   %{"issuer" => "https://accounts.google.com"}
+      ...> }} = Oidcc.ProviderConfiguration.load_configuration_raw(
+      ...>   "https://accounts.google.com",
+      ...>   %{}
+      ...> )
+  """
+  @doc since: "3.9.0"
+  @spec load_configuration_raw(
+          issuer :: :uri_string.uri_string(),
+          opts :: :oidcc_provider_configuration.opts()
+        ) ::
+          {:ok,
+           {configuration :: t(), expiry :: pos_integer(),
+            document :: :oidcc_provider_configuration.document()}}
+          | {:error, :oidcc_provider_configuration.error()}
+  def load_configuration_raw(issuer, opts \\ %{}) do
+    with {:ok, {configuration, expiry, document}} <-
+           :oidcc_provider_configuration.load_configuration_raw(issuer, opts) do
+      {:ok, {record_to_struct(configuration), expiry, document}}
+    end
+  end
+
+  @doc """
   Load JWKs
 
   ## Examples
@@ -170,6 +206,36 @@ defmodule Oidcc.ProviderConfiguration do
     with {:ok, {jwks, expiry}} <-
            :oidcc_provider_configuration.load_jwks(jwks_uri, opts) do
       {:ok, {JOSE.JWK.from_record(jwks), expiry}}
+    end
+  end
+
+  @doc """
+  Load JWKs, keeping the document the provider served
+
+  Same as `load_jwks/2`, but additionally returns the decoded JSON document, for
+  callers that persist the key set rather than only using it.
+
+  ## Examples
+
+      iex> {:ok, {%JOSE.JWK{}, _expiry, %{"keys" => _keys}}} =
+      ...>   Oidcc.ProviderConfiguration.load_jwks_raw(
+      ...>     "https://www.googleapis.com/oauth2/v3/certs",
+      ...>     %{}
+      ...>   )
+  """
+  @doc since: "3.9.0"
+  @spec load_jwks_raw(
+          jwks_uri :: :uri_string.uri_string(),
+          opts :: :oidcc_provider_configuration.opts()
+        ) ::
+          {:ok,
+           {jwks :: JOSE.JWK.t(), expiry :: pos_integer(),
+            document :: :oidcc_provider_configuration.jwks_document()}}
+          | {:error, :oidcc_provider_configuration.error()}
+  def load_jwks_raw(jwks_uri, opts \\ %{}) do
+    with {:ok, {jwks, expiry, document}} <-
+           :oidcc_provider_configuration.load_jwks_raw(jwks_uri, opts) do
+      {:ok, {JOSE.JWK.from_record(jwks), expiry, document}}
     end
   end
 

--- a/src/oidcc_provider_configuration.erl
+++ b/src/oidcc_provider_configuration.erl
@@ -28,8 +28,12 @@ See [`Oidcc.ProviderConfiguration`](`m:'Elixir.Oidcc.ProviderConfiguration'`).
 -export([decode_configuration/2]).
 -export([load_configuration/1]).
 -export([load_configuration/2]).
+-export([load_configuration_raw/2]).
 -export([load_jwks/2]).
+-export([load_jwks_raw/2]).
 
+-export_type([document/0]).
+-export_type([jwks_document/0]).
 -export_type([error/0]).
 -export_type([opts/0]).
 -export_type([quirks/0]).
@@ -151,10 +155,32 @@ All unrecognized fields are stored in `extra_fields`.
         extra_fields :: #{binary() => term()}
     }.
 
+-doc """
+Decoded JSON document as served by the provider.
+
+This is the document the endpoint returned, before `oidcc` merges
+`document_overrides` into it or coerces it into a record. Unlike a decoded
+record it can be re-encoded losslessly, which is what makes it suitable for
+persisting the provider's metadata.
+""".
+-doc #{since => <<"3.9.0">>}.
+-type document() :: #{binary() => term()}.
+
+-doc """
+Decoded JWKS document as served by the provider.
+
+RFC 7517 section 5 defines a JWK Set as a JSON object with a `keys` member, but
+`jose_jwk:from/1` also accepts a bare array of keys and some providers serve
+one, so both shapes reach the caller.
+""".
+-doc #{since => <<"3.9.0">>}.
+-type jwks_document() :: document() | [term()].
+
 -doc #{since => <<"3.0.0">>}.
 -type error() ::
     invalid_content_type
     | {issuer_mismatch, Issuer :: binary()}
+    | {invalid_document, Document :: term()}
     | oidcc_decode_util:error()
     | oidcc_http_util:error().
 
@@ -218,7 +244,39 @@ Load OpenID Configuration into a `t:oidcc_provider_configuration:t/0` record.
 when
     Issuer :: uri_string:uri_string(),
     Opts :: opts().
-load_configuration(Issuer0, Opts) ->
+load_configuration(Issuer, Opts) ->
+    case load_configuration_raw(Issuer, Opts) of
+        {ok, {Configuration, Expiry, _Document}} -> {ok, {Configuration, Expiry}};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-doc """
+Load OpenID Configuration, keeping the document the provider served.
+
+Same as `load_configuration/2`, but additionally returns the decoded JSON
+document. The record cannot be re-encoded losslessly - `extra_fields` holds only
+the keys the decoder did not recognize, every other key is coerced into a typed
+record field, and `issuer_regex` is not an OpenID Discovery field at all - so
+callers that persist provider metadata need the document itself.
+
+## Examples
+
+```erlang
+{ok, {#oidcc_provider_configuration{}, _Expiry, #{<<"issuer">> := Issuer}}} =
+  oidcc_provider_configuration:load_configuration_raw(
+    "https://accounts.google.com",
+    #{}
+  ).
+```
+""".
+-doc #{since => <<"3.9.0">>}.
+-spec load_configuration_raw(Issuer, Opts) ->
+    {ok, {Configuration :: t(), Expiry :: pos_integer(), Document :: document()}}
+    | {error, error()}
+when
+    Issuer :: uri_string:uri_string(),
+    Opts :: opts().
+load_configuration_raw(Issuer0, Opts) ->
     Issuer = binary:list_to_bin([Issuer0]),
     TelemetryOpts = #{topic => [oidcc, load_configuration], extra_meta => #{issuer => Issuer}},
     RequestOpts = maps:get(request_opts, Opts, #{}),
@@ -235,6 +293,10 @@ load_configuration(Issuer0, Opts) ->
     maybe
         {ok, {{json, ConfigurationMap}, Headers}} ?=
             oidcc_http_util:request(get, Request, TelemetryOpts, RequestOpts),
+        %% A JSON document that is not an object is not a discovery document.
+        %% Without this it reaches `maps:merge/2' inside `decode_configuration/2'
+        %% and a provider answering with `null' takes the caller down.
+        true ?= is_map(ConfigurationMap) orelse {invalid_document, ConfigurationMap},
         Expiry = oidcc_http_util:headers_to_cache_deadline(Headers, DefaultExpiry),
         {ok,
             #oidcc_provider_configuration{issuer = ConfigIssuer, issuer_regex = ConfigIssuerRegex} =
@@ -242,20 +304,23 @@ load_configuration(Issuer0, Opts) ->
             decode_configuration(ConfigurationMap, #{quirks => Quirks}),
         case ConfigIssuer of
             Issuer ->
-                {ok, {Configuration, Expiry}};
+                {ok, {Configuration, Expiry, ConfigurationMap}};
             _ when is_binary(ConfigIssuerRegex) ->
                 case re:run(Issuer, ConfigIssuerRegex, [{capture, none}]) of
                     match ->
-                        {ok, {Configuration, Expiry}};
+                        {ok, {Configuration, Expiry, ConfigurationMap}};
                     nomatch ->
                         {error, {issuer_mismatch, ConfigIssuer}}
                 end;
-            _DifferentIssuer when AllowIssuerMismatch -> {ok, {Configuration, Expiry}};
+            _DifferentIssuer when AllowIssuerMismatch ->
+                {ok, {Configuration, Expiry, ConfigurationMap}};
             DifferentIssuer when not AllowIssuerMismatch ->
                 {error, {issuer_mismatch, DifferentIssuer}}
         end
     else
         {error, Reason} ->
+            {error, Reason};
+        {invalid_document, _Document} = Reason ->
             {error, Reason};
         {ok, {{_Format, _Body}, _Headers}} ->
             {error, invalid_content_type}
@@ -286,19 +351,54 @@ when
     JwksUri :: uri_string:uri_string(),
     Opts :: opts().
 load_jwks(JwksUri, Opts) ->
+    case load_jwks_raw(JwksUri, Opts) of
+        {ok, {Jwks, Expiry, _Document}} -> {ok, {Jwks, Expiry}};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-doc """
+Load JWKs, keeping the document the provider served.
+
+Same as `load_jwks/2`, but additionally returns the decoded JSON document, for
+callers that persist the key set rather than only using it.
+
+## Examples
+
+```erlang
+{ok, {#jose_jwk{}, _Expiry, #{<<"keys">> := _Keys}}} =
+  oidcc_provider_configuration:load_jwks_raw(
+    "https://www.googleapis.com/oauth2/v3/certs",
+    #{}
+  ).
+```
+""".
+-doc #{since => <<"3.9.0">>}.
+-spec load_jwks_raw(JwksUri, Opts) ->
+    {ok, {Jwks :: jose_jwk:key(), Expiry :: pos_integer(), Document :: jwks_document()}}
+    | {error, error()}
+when
+    JwksUri :: uri_string:uri_string(),
+    Opts :: opts().
+load_jwks_raw(JwksUri, Opts) ->
     TelemetryOpts = #{topic => [oidcc, load_jwks], extra_meta => #{jwks_uri => JwksUri}},
     RequestOpts = maps:get(request_opts, Opts, #{}),
 
     DefaultExpiry = maps:get(fallback_expiry, Opts, ?DEFAULT_CONFIG_EXPIRY),
 
     maybe
-        {ok, {{json, JwksBinary}, Headers}} ?=
+        {ok, {{json, JwksMap}, Headers}} ?=
             oidcc_http_util:request(get, {JwksUri, []}, TelemetryOpts, RequestOpts),
+        %% `jose_jwk:from/1' takes an object or a bare array of keys and raises
+        %% on anything else, so a provider answering with a scalar would take
+        %% the caller down.
+        true ?=
+            (is_map(JwksMap) orelse is_list(JwksMap)) orelse {invalid_document, JwksMap},
         Expiry = oidcc_http_util:headers_to_cache_deadline(Headers, DefaultExpiry),
-        Jwks = jose_jwk:from(JwksBinary),
-        {ok, {Jwks, Expiry}}
+        Jwks = jose_jwk:from(JwksMap),
+        {ok, {Jwks, Expiry, JwksMap}}
     else
         {error, Reason} -> {error, Reason};
+        {invalid_document, _Document} = Reason -> {error, Reason};
         {ok, {{_Format, _Body}, _Headers}} -> {error, invalid_content_type}
     end.
 

--- a/test/oidcc/provider_configuration_test.exs
+++ b/test/oidcc/provider_configuration_test.exs
@@ -15,10 +15,37 @@ defmodule Oidcc.ProviderConfigurationTest do
     end
   end
 
+  describe inspect(&ProviderConfiguration.load_configuration_raw/2) do
+    test "works" do
+      assert {:ok,
+              {%ProviderConfiguration{issuer: "https://accounts.google.com"}, _expiry, document}} =
+               ProviderConfiguration.load_configuration_raw("https://accounts.google.com", %{})
+
+      assert %{"issuer" => "https://accounts.google.com"} = document
+    end
+
+    test "returns a document that decodes back into the same struct" do
+      assert {:ok, {configuration, _expiry, document}} =
+               ProviderConfiguration.load_configuration_raw("https://accounts.google.com", %{})
+
+      assert {:ok, ^configuration} = ProviderConfiguration.decode_configuration(document)
+    end
+  end
+
   describe inspect(&ProviderConfiguration.load_jwks/2) do
     test "works" do
       assert {:ok, {%JOSE.JWK{}, _expiry}} =
                ProviderConfiguration.load_jwks("https://www.googleapis.com/oauth2/v3/certs", %{})
+    end
+  end
+
+  describe inspect(&ProviderConfiguration.load_jwks_raw/2) do
+    test "works" do
+      assert {:ok, {%JOSE.JWK{}, _expiry, %{"keys" => _keys}}} =
+               ProviderConfiguration.load_jwks_raw(
+                 "https://www.googleapis.com/oauth2/v3/certs",
+                 %{}
+               )
     end
   end
 

--- a/test/oidcc_provider_configuration_test.erl
+++ b/test/oidcc_provider_configuration_test.erl
@@ -612,6 +612,212 @@ issuer_regex_quirk_test() ->
 
     ok.
 
+load_configuration_raw_test() ->
+    PrivDir = code:priv_dir(oidcc),
+    {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+    Document = json:decode(ConfigurationBinary),
+
+    HttpFun =
+        fun(get, _Request, _HttpOpts, _Opts, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/json"}],
+                ConfigurationBinary
+            }}
+        end,
+    RequestOpts = #{
+        request_opts => #{http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}}
+    },
+
+    {ok, {Configuration, Expiry, ReturnedDocument}} =
+        oidcc_provider_configuration:load_configuration_raw(<<"https://my.provider">>, RequestOpts),
+
+    ?assertEqual(Document, ReturnedDocument),
+    ?assertMatch(#oidcc_provider_configuration{issuer = <<"https://my.provider">>}, Configuration),
+
+    %% The 2-arity function keeps returning the pair, built from the same load.
+    ?assertEqual(
+        {ok, {Configuration, Expiry}},
+        oidcc_provider_configuration:load_configuration(<<"https://my.provider">>, RequestOpts)
+    ),
+
+    ok.
+
+load_configuration_raw_returns_wire_document_test() ->
+    PrivDir = code:priv_dir(oidcc),
+    {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+
+    HttpFun =
+        fun(get, _Request, _HttpOpts, _Opts, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/json"}],
+                ConfigurationBinary
+            }}
+        end,
+
+    {ok, {Configuration, _Expiry, Document}} =
+        oidcc_provider_configuration:load_configuration_raw(<<"https://my.provider">>, #{
+            request_opts => #{http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}},
+            quirks => #{
+                document_overrides => #{
+                    <<"token_endpoint">> => <<"https://my.provider/override/token">>
+                }
+            }
+        }),
+
+    %% `document_overrides' is merged while decoding, so the record carries the
+    %% override while the document stays what the provider served.
+    ?assertMatch(
+        #oidcc_provider_configuration{token_endpoint = <<"https://my.provider/override/token">>},
+        Configuration
+    ),
+    ?assertEqual(
+        maps:get(<<"token_endpoint">>, json:decode(ConfigurationBinary)),
+        maps:get(<<"token_endpoint">>, Document)
+    ),
+
+    ok.
+
+load_jwks_raw_test() ->
+    PrivDir = code:priv_dir(oidcc),
+    {ok, JwksBinary} = file:read_file(PrivDir ++ "/test/fixtures/google-jwks.json"),
+
+    HttpFun =
+        fun(get, _Request, _HttpOpts, _Opts, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/jwk-set+json"}],
+                JwksBinary
+            }}
+        end,
+    RequestOpts = #{
+        request_opts => #{http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}}
+    },
+
+    {ok, {Jwks, Expiry, Document}} =
+        oidcc_provider_configuration:load_jwks_raw(<<"https://my.provider/jwks">>, RequestOpts),
+
+    ?assertEqual(json:decode(JwksBinary), Document),
+    ?assertMatch(#{<<"keys">> := _Keys}, Document),
+    ?assertEqual(jose_jwk:from(json:decode(JwksBinary)), Jwks),
+
+    ?assertEqual(
+        {ok, {Jwks, Expiry}},
+        oidcc_provider_configuration:load_jwks(<<"https://my.provider/jwks">>, RequestOpts)
+    ),
+
+    ok.
+
+%% The issuer_regex and allow_issuer_mismatch branches return the document from
+%% their own clauses, and they are the branches multi-tenant providers take, so
+%% they are exactly the population that wants the document persisted.
+load_configuration_raw_issuer_mismatch_branches_test() ->
+    PrivDir = code:priv_dir(oidcc),
+    {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+    Document = json:decode(ConfigurationBinary),
+
+    HttpFun =
+        fun(get, _Request, _HttpOpts, _Opts, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/json"}],
+                ConfigurationBinary
+            }}
+        end,
+    RequestOpts = #{http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}},
+
+    %% Requested issuer differs from the document's, accepted via issuer_regex.
+    ?assertMatch(
+        {ok, {#oidcc_provider_configuration{}, _Expiry, Document}},
+        oidcc_provider_configuration:load_configuration_raw(<<"https://other.provider">>, #{
+            request_opts => RequestOpts,
+            quirks => #{issuer_regex => <<"^https://other\\.provider$">>}
+        })
+    ),
+
+    %% Same, accepted via the deprecated allow_issuer_mismatch quirk.
+    ?assertMatch(
+        {ok, {#oidcc_provider_configuration{}, _Expiry, Document}},
+        oidcc_provider_configuration:load_configuration_raw(<<"https://other.provider">>, #{
+            request_opts => RequestOpts,
+            quirks => #{allow_issuer_mismatch => true}
+        })
+    ),
+
+    ?assertMatch(
+        {error, {issuer_mismatch, <<"https://my.provider">>}},
+        oidcc_provider_configuration:load_configuration_raw(<<"https://other.provider">>, #{
+            request_opts => RequestOpts,
+            quirks => #{issuer_regex => <<"^https://nope$">>}
+        })
+    ),
+
+    ok.
+
+%% A syntactically valid JSON document that is not an object used to reach
+%% `maps:merge/2' and kill the caller.
+load_configuration_raw_non_object_test() ->
+    Body = fun(Json) ->
+        fun(get, _Request, _HttpOpts, _Opts, _Config) ->
+            {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], Json}}
+        end
+    end,
+    Opts = fun(Json) ->
+        #{request_opts => #{http_adapter => {oidcc_http_adapter_test, #{request => Body(Json)}}}}
+    end,
+
+    ?assertEqual(
+        {error, {invalid_document, null}},
+        oidcc_provider_configuration:load_configuration(<<"https://my.provider">>, Opts(<<"null">>))
+    ),
+    ?assertEqual(
+        {error, {invalid_document, []}},
+        oidcc_provider_configuration:load_configuration(<<"https://my.provider">>, Opts(<<"[]">>))
+    ),
+    ?assertEqual(
+        {error, {invalid_document, 1}},
+        oidcc_provider_configuration:load_configuration(<<"https://my.provider">>, Opts(<<"1">>))
+    ),
+
+    %% A JWKS may legitimately be a bare array of keys, so only scalars are
+    %% rejected there.
+    ?assertMatch(
+        {ok, {_Jwks, _Expiry, [#{<<"kty">> := <<"oct">>}]}},
+        oidcc_provider_configuration:load_jwks_raw(
+            <<"https://my.provider/jwks">>,
+            Opts(<<"[{\"kty\":\"oct\",\"k\":\"AAAA\"}]">>)
+        )
+    ),
+    ?assertEqual(
+        {error, {invalid_document, null}},
+        oidcc_provider_configuration:load_jwks_raw(
+            <<"https://my.provider/jwks">>, Opts(<<"null">>)
+        )
+    ),
+
+    ok.
+
+load_configuration_raw_error_test() ->
+    HttpFun =
+        fun(get, _Request, _HttpOpts, _Opts, _Config) ->
+            {ok, {{"HTTP/1.1", 404, "Not Found"}, [], <<>>}}
+        end,
+    RequestOpts = #{
+        request_opts => #{http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}}
+    },
+
+    ?assertMatch(
+        {error, {http_error, 404, <<>>}},
+        oidcc_provider_configuration:load_configuration_raw(<<"https://my.provider">>, RequestOpts)
+    ),
+    ?assertMatch(
+        {error, {http_error, 404, <<>>}},
+        oidcc_provider_configuration:load_jwks_raw(<<"https://my.provider/jwks">>, RequestOpts)
+    ),
+
+    ok.
+
 invalid_json_configuration_test() ->
     HttpFun =
         fun(get, _Request, _HttpOpts, _Opts, _Config) ->


### PR DESCRIPTION
`#oidcc_provider_configuration{}` can't be re-encoded back into the document it came
from. `extra_fields` holds only the keys the decoder didn't recognize, every other key is
coerced into a typed record field, and `issuer_regex` isn't an OpenID Discovery field at
all. So an RP that wants to persist what a provider served, rather than re-fetch it, has
no way to get it.

That's the normal shape for anything not using `oidcc_provider_configuration_worker`.
hex.pm runs OIDC SSO per organization: the provider config lives in Postgres, is shared
across web nodes, and every request rebuilds the client context from the stored document
with `oidcc_client_context:from_manual/4`. Storing the record isn't an option, since it's
an Erlang record whose shape changes between oidcc versions and a serialized copy breaks
on upgrade. The JSON is the stable thing to store.

With no way to ask oidcc for it, the workaround is to capture it out of band. hex.pm's
`oidcc_http_adapter` stashes every response in the process dictionary and the caller
reads it back and decodes the body a second time. That works, but it's correct only by
accident: the stash is last-write-wins and unkeyed, so it depends on `load_configuration/2`
and `load_jwks/2` each issuing exactly one HTTP request. Any change inside oidcc that adds
a second request to either one, a redirect follow or a retry, silently hands back the
wrong document with no error. That's a hard dependency on an implementation detail oidcc
never promised.

This adds `load_configuration_raw/2` and `load_jwks_raw/2`, returning
`{ok, {Configuration, Expiry, Document}}`. The existing 2-arity functions become one-line
delegations that drop the third element, so nothing existing changes shape. `Document` is
the decoded map as it came off the wire, taken before `decode_configuration/2` merges
`document_overrides` into it, so what comes back is what the provider sent and not what
oidcc made of it.

Two alternatives I discarded. A new field on `#oidcc_provider_configuration{}` would reach
the Elixir struct for free, but the hrl is public API shipped in the Hex package, so it
forces downstream recompilation, and `#oidcc_client_context{}` embeds the configuration
record and gets passed to every operation, so every context would carry a second copy of
the document. An opts flag that changes the return shape has no precedent anywhere in
`src/` or `lib/`, and dialyzer can't express it. The closest existing precedent for a wider
success tuple is `oidcc_profile:apply_profiles/2` returning `{ok, ClientContext, Opts}`.

Splitting the loaders surfaced a separate crash, fixed here because the fix is two lines
in the code this PR already moves. Both loaders assumed the decoded JSON was an object. A
provider answering `null` under a JSON content type reached `maps:merge/2` inside
`decode_configuration/2`, and for JWKS a scalar reached `jose_jwk:from/1`, either of which
takes the calling process down. Both now return `{error, {invalid_document, Document}}`, a
new member of `oidcc_provider_configuration:error()`. JWKS accepts an object or a bare
array, since `jose_jwk:from/1` takes both and some providers serve the array form.

The Elixir wrappers mirror both functions and `@type` entries are updated by hand as usual.
