### PR TITLE
Subtract the Age header when computing a cache deadline

### DIFF
--- a/.github/workflows/part_test.yml
+++ b/.github/workflows/part_test.yml
@@ -308,6 +308,7 @@ jobs:
             mix_test_coverage-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-${{ steps.setupBEAM.outputs.elixir-version }}-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: "*-coverage-*"
           path: artifacts
       - name: Unpack Artifacts
         run: |
@@ -358,6 +359,7 @@ jobs:
             cover-${{ runner.os }}-${{ steps.setupBEAM.outputs.otp-version }}-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: "*-coverage-*"
           path: artifacts
       - name: Unpack Artifacts
         run: |

--- a/src/oidcc_http_util.erl
+++ b/src/oidcc_http_util.erl
@@ -233,13 +233,13 @@ is_json_content_type(ContentType) ->
             false
     end.
 
--spec headers_to_cache_deadline(Headers, DefaultExpiry) -> pos_integer() when
-    Headers :: [oidcc_http_adapter:header()], DefaultExpiry :: non_neg_integer().
+-spec headers_to_cache_deadline(Headers, DefaultExpiry) -> non_neg_integer() when
+    Headers :: [oidcc_http_adapter:header()], DefaultExpiry :: pos_integer().
 headers_to_cache_deadline(Headers, DefaultExpiry) ->
     case proplists:lookup("cache-control", Headers) of
         {"cache-control", Cache} ->
             try
-                cache_deadline(Cache, DefaultExpiry)
+                cache_deadline(Cache, header_age(Headers), DefaultExpiry)
             catch
                 _:_ ->
                     DefaultExpiry
@@ -248,34 +248,63 @@ headers_to_cache_deadline(Headers, DefaultExpiry) ->
             DefaultExpiry
     end.
 
--spec cache_deadline(Cache :: iodata(), Fallback :: pos_integer()) -> pos_integer().
-cache_deadline(Cache, Fallback) ->
+-spec cache_deadline(Cache :: iodata(), Age :: non_neg_integer(), Fallback :: pos_integer()) ->
+    non_neg_integer().
+cache_deadline(Cache, Age, Fallback) ->
     %% RFC 7234 §5.2: cache-control directive names are case-insensitive
     %% (`Max-Age', `MAX-AGE', and `max-age' are all valid). Lowercase the
     %% whole header before splitting so the `<<"max-age">>' match below
     %% catches every spelling.
     Lower = string:lowercase(iolist_to_binary(Cache)),
     Entries = binary:split(Lower, [<<",">>, <<"=">>, <<" ">>], [global, trim_all]),
-    clamp_expiry(extract_max_age(Entries, Fallback), Fallback).
+    case extract_max_age(Entries) of
+        undefined ->
+            Fallback;
+        MaxAge ->
+            %% RFC 7234 §4.2: what is left of a stated lifetime is that lifetime
+            %% minus how long the response has already been held, which the
+            %% `Age' header of an intermediary reports. `Age' only ever applies
+            %% to a lifetime the server stated, never to the caller's fallback.
+            max(clamp_expiry(MaxAge, Fallback) - Age, 0)
+    end.
+
+%% RFC 7234 §5.1: `Age' is how many seconds ago the response was generated, as
+%% estimated by whatever shared cache is serving it. A malformed, negative or
+%% absent value contributes nothing rather than shortening the lifetime.
+-spec header_age(Headers :: [oidcc_http_adapter:header()]) -> non_neg_integer().
+header_age(Headers) ->
+    case proplists:lookup("age", Headers) of
+        {"age", Age} ->
+            try binary_to_integer(string:trim(iolist_to_binary(Age))) of
+                Seconds when Seconds > 0 ->
+                    erlang:convert_time_unit(Seconds, second, millisecond);
+                _NonPositive ->
+                    0
+            catch
+                _:_ ->
+                    0
+            end;
+        none ->
+            0
+    end.
 
 %% Walk the cache-control tokens looking for `max-age=<N>' and return N as
-%% milliseconds. If the value is missing, zero, or non-numeric, return the
-%% caller's fallback.
--spec extract_max_age([binary()], pos_integer()) -> pos_integer().
-extract_max_age([<<"max-age">>, Value | _Rest], Fallback) ->
+%% milliseconds, or `undefined' when the value is missing, zero, or non-numeric.
+-spec extract_max_age([binary()]) -> non_neg_integer() | undefined.
+extract_max_age([<<"max-age">>, Value | _Rest]) ->
     try binary_to_integer(Value) of
         N when N > 0 ->
             erlang:convert_time_unit(N, second, millisecond);
         _ ->
-            Fallback
+            undefined
     catch
         _:_ ->
-            Fallback
+            undefined
     end;
-extract_max_age([_ | Rest], Fallback) ->
-    extract_max_age(Rest, Fallback);
-extract_max_age([], Fallback) ->
-    Fallback.
+extract_max_age([_ | Rest]) ->
+    extract_max_age(Rest);
+extract_max_age([]) ->
+    undefined.
 
 %% `erlang:send_after/3' (used by `oidcc_provider_configuration_worker') and
 %% `timer:send_after/2' both accept at most 16#FFFFFFFF ms (~49.7 days).

--- a/src/oidcc_provider_configuration.erl
+++ b/src/oidcc_provider_configuration.erl
@@ -185,6 +185,7 @@ one, so both shapes reach the caller.
     | oidcc_http_util:error().
 
 -define(DEFAULT_CONFIG_EXPIRY, timer:minutes(15)).
+-define(MINIMUM_REFRESH, timer:minutes(1)).
 
 -telemetry_event(#{
     event => [oidcc, load_configuration, start],
@@ -297,7 +298,7 @@ load_configuration_raw(Issuer0, Opts) ->
         %% Without this it reaches `maps:merge/2' inside `decode_configuration/2'
         %% and a provider answering with `null' takes the caller down.
         true ?= is_map(ConfigurationMap) orelse {invalid_document, ConfigurationMap},
-        Expiry = oidcc_http_util:headers_to_cache_deadline(Headers, DefaultExpiry),
+        Expiry = cache_deadline(Headers, DefaultExpiry),
         {ok,
             #oidcc_provider_configuration{issuer = ConfigIssuer, issuer_regex = ConfigIssuerRegex} =
                 Configuration} ?=
@@ -393,7 +394,7 @@ load_jwks_raw(JwksUri, Opts) ->
         %% the caller down.
         true ?=
             (is_map(JwksMap) orelse is_list(JwksMap)) orelse {invalid_document, JwksMap},
-        Expiry = oidcc_http_util:headers_to_cache_deadline(Headers, DefaultExpiry),
+        Expiry = cache_deadline(Headers, DefaultExpiry),
         Jwks = jose_jwk:from(JwksMap),
         {ok, {Jwks, Expiry, JwksMap}}
     else
@@ -401,6 +402,20 @@ load_jwks_raw(JwksUri, Opts) ->
         {invalid_document, _Document} = Reason -> {error, Reason};
         {ok, {{_Format, _Body}, _Headers}} -> {error, invalid_content_type}
     end.
+
+%% `headers_to_cache_deadline/2' reports what is honestly left of the response's
+%% lifetime, which can be nothing. Callers of this module drive a refresh timer
+%% off the result, so a deadline near zero is a request loop rather than a fresh
+%% document.
+-spec cache_deadline(Headers, DefaultExpiry) -> pos_integer() when
+    Headers :: [oidcc_http_adapter:header()],
+    DefaultExpiry :: pos_integer().
+cache_deadline(Headers, DefaultExpiry) ->
+    Deadline = oidcc_http_util:headers_to_cache_deadline(Headers, DefaultExpiry),
+    %% Bounded by the fallback so a caller asking for a short refresh interval
+    %% still gets it: the floor is there to stop a near-zero deadline, not to
+    %% overrule an interval the caller chose deliberately.
+    max(Deadline, min(?MINIMUM_REFRESH, DefaultExpiry)).
 
 -doc """
 Decode JSON into a `t:oidcc_provider_configuration:t/0` record.

--- a/test/oidcc_http_util_test.erl
+++ b/test/oidcc_http_util_test.erl
@@ -70,3 +70,72 @@ headers_to_cache_deadline_test() ->
     ),
 
     ok.
+
+headers_to_cache_deadline_age_test() ->
+    %% RFC 7234 §5.1 / §4.2: a document a shared cache has already held for
+    %% `Age' seconds has that much less of its stated lifetime left.
+    ?assertEqual(
+        timer:seconds(240),
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age=300"}, {"age", "60"}], 1000
+        )
+    ),
+
+    %% Nothing left. Zero is honest here; holding the deadline above a usable
+    %% refresh interval is the caller's job.
+    ?assertEqual(
+        0,
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age=300"}, {"age", "300"}], 1000
+        )
+    ),
+    ?assertEqual(
+        0,
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age=300"}, {"age", "3600"}], 1000
+        )
+    ),
+
+    %% `Age' never reduces the caller's fallback, which is a refresh interval
+    %% rather than a lifetime the server claimed.
+    ?assertEqual(
+        timer:seconds(1000),
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "public"}, {"age", "60"}], timer:seconds(1000)
+        )
+    ),
+    ?assertEqual(
+        1000,
+        oidcc_http_util:headers_to_cache_deadline([{"age", "60"}], 1000)
+    ),
+    ?assertEqual(
+        1000,
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age=0"}, {"age", "60"}], 1000
+        )
+    ),
+
+    %% A malformed, negative or multi-valued `Age' contributes nothing rather
+    %% than shortening the lifetime.
+    lists:foreach(
+        fun(Age) ->
+            ?assertEqual(
+                timer:seconds(300),
+                oidcc_http_util:headers_to_cache_deadline(
+                    [{"cache-control", "max-age=300"}, {"age", Age}], 1000
+                ),
+                Age
+            )
+        end,
+        ["later", "-60", "60.5", "60, 120", ""]
+    ),
+
+    %% The upper clamp still applies, and is applied before the subtraction.
+    ?assertEqual(
+        16#FFFFFFFF - timer:seconds(10),
+        oidcc_http_util:headers_to_cache_deadline(
+            [{"cache-control", "max-age=99999999999"}, {"age", "10"}], 1000
+        )
+    ),
+
+    ok.

--- a/test/oidcc_provider_configuration_SUITE.erl
+++ b/test/oidcc_provider_configuration_SUITE.erl
@@ -30,7 +30,7 @@ load_configuration(_Config) ->
                 token_endpoint =
                     <<"https://oauth2.googleapis.com/token">>
             },
-            3_600_000
+            _Expiry
         }},
         oidcc_provider_configuration:load_configuration(
             <<"https://accounts.google.com">>,
@@ -57,13 +57,17 @@ load_jwks(_Config) ->
     ).
 
 reads_configuration_expiry(_Config) ->
-    ?assertMatch(
-        {ok, {#oidcc_provider_configuration{}, 3_600_000}},
+    {ok, {#oidcc_provider_configuration{}, Expiry}} =
         oidcc_provider_configuration:load_configuration(
             <<"https://accounts.google.com">>,
             #{}
-        )
-    ).
+        ),
+
+    %% Google serves discovery with `max-age=3600` through a CDN, so what is
+    %% left of that lifetime depends on the `Age` of the copy handed to us. The
+    %% floor keeps it usable, the ceiling proves `Age` was applied at all.
+    ?assert(Expiry >= timer:minutes(1)),
+    ?assert(Expiry =< timer:seconds(3600)).
 
 load_well_known_openid_introspections(_Config) ->
     %% Google

--- a/test/oidcc_provider_configuration_test.erl
+++ b/test/oidcc_provider_configuration_test.erl
@@ -818,6 +818,117 @@ load_configuration_raw_error_test() ->
 
     ok.
 
+%% A response arriving with almost none of its `max-age` left reports a deadline
+%% near zero. Callers drive a refresh timer off it, so the loaders floor it
+%% rather than scheduling an immediate reload.
+minimum_refresh_floors_stale_response_test() ->
+    PrivDir = code:priv_dir(oidcc),
+    {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+
+    Load = fun(CacheHeaders, Opts) ->
+        HttpFun =
+            fun(get, _Request, _HttpOpts, _Opts, _Config) ->
+                {ok, {
+                    {"HTTP/1.1", 200, "OK"},
+                    [{"content-type", "application/json"} | CacheHeaders],
+                    ConfigurationBinary
+                }}
+            end,
+        oidcc_provider_configuration:load_configuration(
+            <<"https://my.provider">>,
+            maps:merge(Opts, #{
+                request_opts => #{
+                    http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}
+                }
+            })
+        )
+    end,
+
+    Stale = [{"cache-control", "max-age=3600"}, {"age", "3599"}],
+
+    ?assertMatch(
+        {ok, {#oidcc_provider_configuration{}, 60_000}},
+        Load(Stale, #{})
+    ),
+    %% The floor never raises the interval above what the caller asked for as a
+    %% fallback, so a caller wanting a shorter one still gets it.
+    ?assertMatch(
+        {ok, {#oidcc_provider_configuration{}, 5_000}},
+        Load(Stale, #{fallback_expiry => 5_000})
+    ),
+
+    %% A lifetime comfortably above the floor is passed through, less its Age.
+    ?assertMatch(
+        {ok, {#oidcc_provider_configuration{}, 240_000}},
+        Load([{"cache-control", "max-age=300"}, {"age", "60"}], #{})
+    ),
+
+    %% `max-age=0, no-store` still lands on the fallback, as issue #370 needs.
+    ?assertMatch(
+        {ok, {#oidcc_provider_configuration{}, 12_345}},
+        Load([{"cache-control", "max-age=0, no-store"}], #{fallback_expiry => 12_345})
+    ),
+
+    ok.
+
+%% The measurement that matters: a nearly-stale provider must not turn the
+%% worker into a request loop.
+stale_response_does_not_loop_test() ->
+    Counter = atomics:new(1, []),
+    DiscoveryBody = iolist_to_binary(
+        json:encode(#{
+            issuer => <<"https://example.com">>,
+            jwks_uri => <<"https://example.com/keys">>,
+            authorization_endpoint => <<"https://example.com/authorize">>,
+            scopes_supported => [<<"openid">>],
+            response_types_supported => [<<"code">>],
+            subject_types_supported => [<<"public">>],
+            id_token_signing_alg_values_supported => [<<"RS256">>]
+        })
+    ),
+    Headers = [
+        {"content-type", "application/json"},
+        {"cache-control", "max-age=3600"},
+        {"age", "3599"}
+    ],
+    HttpFun =
+        fun(get, {Url, []}, _HttpOpts, _Opts, _Profile) ->
+            atomics:add(Counter, 1, 1),
+            Body =
+                case iolist_to_binary(Url) of
+                    <<"https://example.com/keys">> ->
+                        iolist_to_binary(json:encode(#{keys => []}));
+                    _Discovery ->
+                        DiscoveryBody
+                end,
+            {ok, {{"HTTP/1.1", 200, "OK"}, Headers, Body}}
+        end,
+
+    {ok, Pid} =
+        oidcc_provider_configuration_worker:start_link(#{
+            issuer => <<"https://example.com">>,
+            provider_configuration_opts => #{
+                request_opts => #{
+                    http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}
+                }
+            }
+        }),
+
+    try
+        ?assertNotEqual(
+            undefined,
+            oidcc_provider_configuration_worker:get_provider_configuration(Pid)
+        ),
+        timer:sleep(1_000),
+        %% One discovery plus one JWKS load. Without the floor this was a
+        %% sustained one request per second per endpoint.
+        ?assert(atomics:get(Counter, 1) =< 4)
+    after
+        gen_server:stop(Pid)
+    end,
+
+    ok.
+
 invalid_json_configuration_test() ->
     HttpFun =
         fun(get, _Request, _HttpOpts, _Opts, _Config) ->


### PR DESCRIPTION
`headers_to_cache_deadline/2` computes freshness from `max-age` alone. RFC 7234 §4.2
defines it as `max-age` minus the `Age` header, and `Age` is what a shared cache reports
about how long it has already been holding the response. Dropping that term means a
document a CDN has held for most of its lifetime is treated as brand new.

That's measurable against a live provider. Two assertions in
`oidcc_provider_configuration_SUITE` hard-code `3_600_000` for Google's discovery expiry;
with the `Age` subtraction they come back around `1_751_000`, because Google served that
response with roughly 1849 seconds of age. So oidcc reported a document with 30 minutes
of freshness left as having a full hour. As `Age` approaches `max-age` the reported
lifetime approaches double the truth. Those two assertions become range checks here,
since the exact number now depends on how long the CDN had the response.

It matters most to `oidcc_provider_configuration_worker`, which drives `erlang:send_after/3`
off this value and so schedules its refresh late by whatever the `Age` was. Callers that
persist the derived timestamp rather than holding it in one process carry the error for
as long as they cache it.

The subtraction alone isn't safe, which is the other half of this change. Before it, the
only route to a small deadline was a provider sending a small `max-age`, and exactly zero
was impossible because `clamp_expiry/2` sends non-positive values to the fallback. After
it, any response a shared cache is serving near the end of its lifetime produces one, and
zero is reachable. The worker hands that straight to `erlang:send_after/3` and the backoff
only fires on `{error, _}`, so it's an immediate refetch with nothing damping it: 6 requests
in 3 seconds against 2. So `oidcc_provider_configuration` floors the deadline with
`max(Deadline, min(?MINIMUM_REFRESH, DefaultExpiry))`, one minute. The inner `min` keeps a
caller that deliberately asked for a shorter `fallback_expiry` from having it overruled.
Flooring there rather than in the worker is what keeps `Expiry :: pos_integer()` true in
the loaders' specs instead of widening to admit zero.

`no-cache` and `no-store` are deliberately left alone. Honouring them means returning zero,
which is issue #370: kanidm sends `no-store, no-cache, max-age=0` on discovery, and commit
`31c7f3d` fixed the resulting crash by falling back to the caller's expiry. Reversing that
here would reintroduce it, and an RP refetching discovery on every request is not what a
provider misconfiguring its cache headers should get.

`headers_to_cache_deadline/2`'s return widens from `pos_integer()` to `non_neg_integer()`,
which is the one part of this that isn't strictly additive. It's the only export in
`oidcc_http_util` without `-doc false`, so it's hexdocs-visible by omission rather than by
intent, and both in-tree callers go through `oidcc_provider_configuration`, which floors
the value before it reaches anyone. Say the word if you'd rather it were hidden.
