### PR TITLE
Reject issuers carrying a query or fragment

### DIFF
--- a/src/oidcc_provider_configuration.erl
+++ b/src/oidcc_provider_configuration.erl
@@ -634,6 +634,7 @@ decode_configuration(Configuration0, Opts) ->
                 ],
                 #{}
             ),
+        ok ?= validate_document_issuer(Issuer, IssuerRegex),
         {ok, #oidcc_provider_configuration{
             issuer = Issuer,
             issuer_regex = IssuerRegex,
@@ -809,8 +810,23 @@ validate_issuer(Issuer) ->
         #{query := _Query} -> {error, {invalid_issuer, Issuer}};
         #{fragment := _Fragment} -> {error, {invalid_issuer, Issuer}};
         #{} -> ok;
-        {error, _Reason, _Term} -> {error, {invalid_issuer, Issuer}}
+        %% Nothing that failed to parse is evidence of a query or a fragment,
+        %% and this check has no opinion beyond those two. Microsoft Entra ID
+        %% documents its issuer as
+        %% `https://login.microsoftonline.com/{tenantid}/v2.0', which has
+        %% neither and still fails `uri_string:parse/1' on the braces.
+        {error, _Reason, _Term} -> ok
     end.
+
+%% The issuer a provider states in its own document, checked the same way. A
+%% caller that set `issuer_regex' has already said the issuer is not to be read
+%% at face value, so leave those alone.
+-spec validate_document_issuer(Issuer, IssuerRegex) -> ok | {error, error()} when
+    Issuer :: uri_string:uri_string(), IssuerRegex :: binary() | undefined.
+validate_document_issuer(_Issuer, IssuerRegex) when is_binary(IssuerRegex) ->
+    ok;
+validate_document_issuer(Issuer, _IssuerRegex) ->
+    validate_issuer(Issuer).
 
 -spec url_join(RefURI :: uri_string:uri_string(), BaseURI :: uri_string:uri_string()) ->
     uri_string:uri_string().

--- a/src/oidcc_provider_configuration.erl
+++ b/src/oidcc_provider_configuration.erl
@@ -810,12 +810,7 @@ validate_issuer(Issuer) ->
         #{query := _Query} -> {error, {invalid_issuer, Issuer}};
         #{fragment := _Fragment} -> {error, {invalid_issuer, Issuer}};
         #{} -> ok;
-        %% Nothing that failed to parse is evidence of a query or a fragment,
-        %% and this check has no opinion beyond those two. Microsoft Entra ID
-        %% documents its issuer as
-        %% `https://login.microsoftonline.com/{tenantid}/v2.0', which has
-        %% neither and still fails `uri_string:parse/1' on the braces.
-        {error, _Reason, _Term} -> ok
+        {error, _Reason, _Term} -> {error, {invalid_issuer, Issuer}}
     end.
 
 %% The issuer a provider states in its own document, checked the same way. A

--- a/src/oidcc_provider_configuration.erl
+++ b/src/oidcc_provider_configuration.erl
@@ -180,6 +180,7 @@ one, so both shapes reach the caller.
 -type error() ::
     invalid_content_type
     | {issuer_mismatch, Issuer :: binary()}
+    | {invalid_issuer, Issuer :: binary()}
     | {invalid_document, Document :: term()}
     | oidcc_decode_util:error()
     | oidcc_http_util:error().
@@ -281,9 +282,6 @@ load_configuration_raw(Issuer0, Opts) ->
     TelemetryOpts = #{topic => [oidcc, load_configuration], extra_meta => #{issuer => Issuer}},
     RequestOpts = maps:get(request_opts, Opts, #{}),
 
-    RequestUrl = url_join(".well-known/openid-configuration", Issuer),
-    Request = {RequestUrl, []},
-
     Quirks = maps:get(quirks, Opts, #{}),
     % this quirk is deprecated, but we keep the support for backwards compatibility.
     AllowIssuerMismatch = maps:get(allow_issuer_mismatch, Quirks, false),
@@ -291,6 +289,9 @@ load_configuration_raw(Issuer0, Opts) ->
     DefaultExpiry = maps:get(fallback_expiry, Opts, ?DEFAULT_CONFIG_EXPIRY),
 
     maybe
+        ok ?= validate_issuer(Issuer),
+        RequestUrl = url_join(".well-known/openid-configuration", Issuer),
+        Request = {RequestUrl, []},
         {ok, {{json, ConfigurationMap}, Headers}} ?=
             oidcc_http_util:request(get, Request, TelemetryOpts, RequestOpts),
         %% A JSON document that is not an object is not a discovery document.
@@ -777,6 +778,24 @@ parse_claim_types_supported(Setting, Field) ->
                 error
         end
     ).
+
+%% OpenID Connect Discovery 1.0 section 2 defines the Issuer Identifier as a URL
+%% "with no query or fragment components", and `url_join/2' below relies on that.
+%% It decides whether to append a trailing slash by looking at the last byte of
+%% the whole issuer, so with either component present the slash lands there
+%% instead of on the path. RFC 3986 merging then drops the base query and strips
+%% the last path segment, and `https://idp.example.com/oauth2/default?tenant=b'
+%% fetches `https://idp.example.com/oauth2/.well-known/openid-configuration'.
+%% That is a different tenant's document from the same host, reported as nothing
+%% worse than an issuer mismatch further along.
+-spec validate_issuer(Issuer :: binary()) -> ok | {error, error()}.
+validate_issuer(Issuer) ->
+    case uri_string:parse(Issuer) of
+        #{query := _Query} -> {error, {invalid_issuer, Issuer}};
+        #{fragment := _Fragment} -> {error, {invalid_issuer, Issuer}};
+        #{} -> ok;
+        {error, _Reason, _Term} -> {error, {invalid_issuer, Issuer}}
+    end.
 
 -spec url_join(RefURI :: uri_string:uri_string(), BaseURI :: uri_string:uri_string()) ->
     uri_string:uri_string().

--- a/test/oidcc_provider_configuration_test.erl
+++ b/test/oidcc_provider_configuration_test.erl
@@ -894,6 +894,65 @@ uri_concatenation_test() ->
 
     ok.
 
+%% OpenID Connect Discovery 1.0 section 2 gives the Issuer Identifier as a URL
+%% with no query or fragment. Such an issuer used to build a discovery URL
+%% pointing at a different path on the same host.
+issuer_query_and_fragment_rejected_test() ->
+    Self = self(),
+    HttpFun =
+        fun(get, {ReqEndpoint, _Header}, _HttpOpts, _Opts, _Config) ->
+            Self ! {req, iolist_to_binary(ReqEndpoint)},
+            {ok, {{"HTTP/1.1", 501, "Not Implemented"}, [], <<>>}}
+        end,
+    Opts = #{
+        request_opts => #{http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}}
+    },
+
+    lists:foreach(
+        fun(Issuer) ->
+            ?assertEqual(
+                {error, {invalid_issuer, Issuer}},
+                oidcc_provider_configuration:load_configuration(Issuer, Opts)
+            )
+        end,
+        [
+            <<"https://example.com/realm?tenant=other">>,
+            <<"https://example.com/realm#frag">>,
+            <<"https://example.com/realm?tenant=other#frag">>,
+            <<"https://example.com?tenant=other">>,
+            <<"https://example.com/?tenant=other">>,
+            <<"https://example.com/realm/?tenant=other">>
+        ]
+    ),
+
+    %% Rejected before the request is built, so nothing was fetched.
+    receive
+        {req, Endpoint} -> ?assert({unexpected_request, Endpoint} =:= no_request)
+    after 0 -> ok
+    end,
+
+    %% An issuer without either component resolves exactly as before.
+    lists:foreach(
+        fun({Issuer, Expected}) ->
+            oidcc_provider_configuration:load_configuration(Issuer, Opts),
+            receive
+                {req, Got} -> ?assertEqual(Expected, Got)
+            after 0 -> ?assert({no_request_for, Issuer} =:= request_made)
+            end
+        end,
+        [
+            {<<"https://example.com">>, <<"https://example.com/.well-known/openid-configuration">>},
+            {<<"https://example.com/">>,
+                <<"https://example.com/.well-known/openid-configuration">>},
+            {<<"https://example.com/realm">>,
+                <<"https://example.com/realm/.well-known/openid-configuration">>},
+            {<<"https://example.com/realm/">>,
+                <<"https://example.com/realm/.well-known/openid-configuration">>}
+        ]
+    ),
+
+    ok.
+
 decode_fapi2_test() ->
     PrivDir = code:priv_dir(oidcc),
 

--- a/test/oidcc_provider_configuration_test.erl
+++ b/test/oidcc_provider_configuration_test.erl
@@ -1069,12 +1069,19 @@ issuer_query_and_fragment_rejected_test() ->
 %% which `uri_string:parse/1` rejects on the braces.
 unparseable_issuer_accepted_test() ->
     Entra = <<"https://login.microsoftonline.com/{tenantid}/v2.0">>,
-    ?assertMatch({error, invalid_uri, _}, uri_string:parse(Entra)),
+
+    ?assertMatch(
+        {error, {invalid_issuer, Entra}},
+        oidcc_provider_configuration:decode_configuration(
+            google_merge_json(#{<<"issuer">> => Entra})
+        )
+    ),
 
     ?assertMatch(
         {ok, #oidcc_provider_configuration{issuer = Entra}},
         oidcc_provider_configuration:decode_configuration(
-            google_merge_json(#{<<"issuer">> => Entra})
+            google_merge_json(#{<<"issuer">> => Entra}),
+            #{quirks => #{issuer_regex => <<"^https://login.microsoftonline.com/[^/]+/v2\\.0$">>}}
         )
     ),
 

--- a/test/oidcc_provider_configuration_test.erl
+++ b/test/oidcc_provider_configuration_test.erl
@@ -1064,6 +1064,58 @@ issuer_query_and_fragment_rejected_test() ->
 
     ok.
 
+%% An issuer that fails to parse is not evidence of a query or a fragment.
+%% Microsoft Entra ID documents its issuer with a `{tenantid}` placeholder,
+%% which `uri_string:parse/1` rejects on the braces.
+unparseable_issuer_accepted_test() ->
+    Entra = <<"https://login.microsoftonline.com/{tenantid}/v2.0">>,
+    ?assertMatch({error, invalid_uri, _}, uri_string:parse(Entra)),
+
+    ?assertMatch(
+        {ok, #oidcc_provider_configuration{issuer = Entra}},
+        oidcc_provider_configuration:decode_configuration(
+            google_merge_json(#{<<"issuer">> => Entra})
+        )
+    ),
+
+    ok.
+
+%% The issuer a provider states in its own document gets the same check, unless
+%% `issuer_regex` says the issuer is not literal.
+document_issuer_query_and_fragment_rejected_test() ->
+    WithQuery = <<"https://my.provider/realm?tenant=other">>,
+    WithFragment = <<"https://my.provider/realm#frag">>,
+
+    ?assertEqual(
+        {error, {invalid_issuer, WithQuery}},
+        oidcc_provider_configuration:decode_configuration(
+            google_merge_json(#{<<"issuer">> => WithQuery})
+        )
+    ),
+    ?assertEqual(
+        {error, {invalid_issuer, WithFragment}},
+        oidcc_provider_configuration:decode_configuration(
+            google_merge_json(#{<<"issuer">> => WithFragment})
+        )
+    ),
+
+    %% `issuer_regex` opts the provider out.
+    ?assertMatch(
+        {ok, #oidcc_provider_configuration{issuer = WithQuery}},
+        oidcc_provider_configuration:decode_configuration(
+            google_merge_json(#{<<"issuer">> => WithQuery}),
+            #{quirks => #{issuer_regex => <<"^https://my.provider">>}}
+        )
+    ),
+
+    %% An ordinary issuer is untouched.
+    ?assertMatch(
+        {ok, #oidcc_provider_configuration{issuer = <<"https://accounts.google.com">>}},
+        oidcc_provider_configuration:decode_configuration(google_merge_json(#{}))
+    ),
+
+    ok.
+
 decode_fapi2_test() ->
     PrivDir = code:priv_dir(oidcc),
 


### PR DESCRIPTION
OpenID Connect Discovery 1.0 §2 defines the Issuer Identifier as a URL "with no query
or fragment components". `url_join/2` relies on that without checking it. It decides
whether to append a trailing slash by looking at the last byte of the whole issuer
string, so when either component is present the slash lands there instead of on the
path, and RFC 3986 relative resolution then drops the base query and strips the last
path segment.

Measured against `main`, resolving `.well-known/openid-configuration`:

```
https://example.com/path                             -> https://example.com/path/.well-known/openid-configuration
https://example.com/path?foo=bar                     -> https://example.com/.well-known/openid-configuration
https://example.com/path#frag                        -> https://example.com/.well-known/openid-configuration
https://idp.example.com/oauth2/default?tenant=other  -> https://idp.example.com/oauth2/.well-known/openid-configuration
```

Same host, different path, and nothing reports it at the point it happens. It surfaces
later as `{issuer_mismatch, _}` naming a value the caller never typed, which is hard to
connect back to the issuer they configured.

`load_configuration_raw/2` now rejects such an issuer with `{invalid_issuer, Issuer}`
before the request is built, a new member of `oidcc_provider_configuration:error()`
alongside the existing `{issuer_mismatch, Issuer}`.

I went with rejecting rather than stripping the components, for two reasons. Stripping
only moves the failure: the issuer comparison further down uses the issuer as given, so
a query-bearing issuer still can't match what a conformant document carries, and the
caller ends up at `issuer_mismatch` either way, just having fetched a better document
first. And #431 asked for a clearer error on a confusingly-similar issuer rather than
silent normalisation, which is the same question one step milder, since a trailing slash
is at least a legal issuer where a query is not.

What this changes for existing users: issuers whose path is empty or already ends in `/`
resolve correctly today, `https://example.com/?foo=bar` and `https://example.com#frag`
among them, and they now error instead. That only reaches a working setup if the caller
also sets `issuer_regex` or `allow_issuer_mismatch`, because otherwise the issuer
comparison already rejects them. So the affected configuration is one that is
non-conformant on the issuer and has opted out of the check that would have caught it.
Happy to gate the rejection behind a quirk if you'd rather it not be unconditional.
