### PR TITLE
Report what a JWKS refresh fetched

### DIFF
--- a/lib/oidcc/token.ex
+++ b/lib/oidcc/token.ex
@@ -168,6 +168,50 @@ defmodule Oidcc.Token do
   end
 
   @doc """
+  Retrieve the token, reporting what a JWKS refresh fetched
+
+  Same as `retrieve/3`, but the third element carries whatever the
+  `refresh_jwks` function returned alongside the refreshed keys, or `:undefined`
+  when no refresh happened.
+
+  oidcc refreshes the keys and retries validation without re-sending the
+  authorization code, which is single use, so this is the only way to learn what
+  that refresh fetched. Persisting the refreshed key set is the usual reason to
+  want it.
+
+  ## Examples
+
+      refresh_jwks = fn _old_jwks, _kid ->
+        {:ok, {jwks, expiry, document}} =
+          Oidcc.ProviderConfiguration.load_jwks_raw(jwks_uri, %{})
+
+        {:ok, JOSE.JWK.to_record(jwks), {document, expiry}}
+      end
+
+      {:ok, %Oidcc.Token{}, {document, expiry}} =
+        Oidcc.Token.retrieve_with_refresh(auth_code, client_context, %{
+          redirect_uri: "https://my.server/return",
+          refresh_jwks: refresh_jwks
+        })
+
+  """
+  @doc since: "3.9.0"
+  @spec retrieve_with_refresh(
+          auth_code :: String.t(),
+          client_context :: ClientContext.t(),
+          opts :: retrieve_opts()
+        ) ::
+          {:ok, t(), :oidcc_token.refresh_info()} | {:error, :oidcc_token.error()}
+  def retrieve_with_refresh(auth_code, client_context, opts) do
+    client_context = ClientContext.struct_to_record(client_context)
+
+    case :oidcc_token.retrieve_with_refresh(auth_code, client_context, opts) do
+      {:ok, token, info} -> {:ok, record_to_struct(token), info}
+      {:error, reason} -> {:error, reason} |> normalize_token_response()
+    end
+  end
+
+  @doc """
   Validate the JARM response, returning the valid claims as a map.
 
   the response was sent to the local endpoint by the OpenId Connect provider,

--- a/src/oidcc_jwt_util.erl
+++ b/src/oidcc_jwt_util.erl
@@ -32,9 +32,23 @@
 -export_type([error/0]).
 -export_type([refresh_jwks_for_unknown_kid_fun/0]).
 
+-doc """
+How to fetch a key set when a token names a `kid` the current one lacks.
+
+The three element return reports something back to whoever started the
+operation, reachable through `oidcc_token:retrieve_with_refresh/3`. `oidcc` does
+not interpret it. Without it, a function that fetched the key set has no way to
+hand the document or its expiry back to its own caller, because `oidcc` calls it
+and consumes the result.
+""".
 -doc #{since => <<"3.0.0">>}.
 -type refresh_jwks_for_unknown_kid_fun() ::
-    fun((Jwks :: jose_jwk:key(), Kid :: binary()) -> {ok, jose_jwk:key()} | {error, term()}).
+    fun(
+        (Jwks :: jose_jwk:key(), Kid :: binary()) ->
+            {ok, jose_jwk:key()}
+            | {ok, jose_jwk:key(), Info :: term()}
+            | {error, term()}
+    ).
 
 -doc #{since => <<"3.0.0">>}.
 -type error() ::

--- a/src/oidcc_token.erl
+++ b/src/oidcc_token.erl
@@ -35,6 +35,7 @@ See [`Oidcc.Token`](`m:'Elixir.Oidcc.Token'`).
 -export([jwt_profile/4]).
 -export([refresh/3]).
 -export([retrieve/3]).
+-export([retrieve_with_refresh/3]).
 -export([validate_jarm/3]).
 -export([validate_id_token/3]).
 -export([validate_jwt/3]).
@@ -50,6 +51,7 @@ See [`Oidcc.Token`](`m:'Elixir.Oidcc.Token'`).
 -export_type([refresh/0]).
 -export_type([refresh_opts/0]).
 -export_type([refresh_opts_no_sub/0]).
+-export_type([refresh_info/0]).
 -export_type([retrieve_opts/0]).
 -export_type([validate_jarm_opts/0]).
 -export_type([validate_jwt_opts/0]).
@@ -235,6 +237,15 @@ See https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3.
         refresh_jwks => oidcc_jwt_util:refresh_jwks_for_unknown_kid_fun()
     }.
 
+-doc """
+Whatever a `refresh_jwks` function reported alongside the refreshed keys.
+
+`undefined` when no refresh happened, or when the function used the two element
+return that carries only the keys. `oidcc` does not interpret it.
+""".
+-doc #{since => <<"3.9.0">>}.
+-type refresh_info() :: term() | undefined.
+
 -doc #{since => <<"3.0.0">>}.
 -type error() ::
     {missing_claim, MissingClaim :: binary(), Claims :: oidcc_jwt_util:claims()}
@@ -372,6 +383,43 @@ when
     ClientContext :: oidcc_client_context:t(),
     Opts :: retrieve_opts().
 retrieve(AuthCode, ClientContext, Opts) ->
+    case retrieve_with_refresh(AuthCode, ClientContext, Opts) of
+        {ok, Token, _Info} -> {ok, Token};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-doc """
+Retrieve the token, reporting what a JWKS refresh fetched.
+
+Same as `retrieve/3`, but the third element carries whatever the `refresh_jwks`
+function returned alongside the refreshed keys, or `undefined` when no refresh
+happened. A function using the two element `{ok, Jwks}` return reports nothing.
+
+`oidcc` refreshes the keys and retries validation without re-sending the
+authorization code, which is single use, so this is the only way to learn what
+that refresh fetched. Persisting the refreshed key set is the usual reason to
+want it.
+
+## Examples
+
+```erlang
+RefreshJwks = fun(_OldJwks, _Kid) ->
+    {ok, {Jwks, Expiry, Document}} = oidcc_provider_configuration:load_jwks_raw(JwksUri, #{}),
+    {ok, Jwks, {Document, Expiry}}
+end,
+
+{ok, #oidcc_token{}, {Document, Expiry}} =
+    oidcc_token:retrieve_with_refresh(AuthCode, ClientContext, Opts#{refresh_jwks => RefreshJwks}).
+```
+""".
+-doc #{since => <<"3.9.0">>}.
+-spec retrieve_with_refresh(AuthCode, ClientContext, Opts) ->
+    {ok, t(), refresh_info()} | {error, error()}
+when
+    AuthCode :: binary(),
+    ClientContext :: oidcc_client_context:t(),
+    Opts :: retrieve_opts().
+retrieve_with_refresh(AuthCode, ClientContext, Opts) ->
     #oidcc_client_context{
         provider_configuration = Configuration,
         client_id = ClientId
@@ -557,7 +605,7 @@ refresh(RefreshToken, ClientContext, Opts) ->
             maybe
                 {ok, Token} ?=
                     retrieve_a_token(QueryString1, ClientContext, Opts, TelemetryOpts, true),
-                {ok, TokenRecord} ?=
+                {ok, TokenRecord, _Info} ?=
                     extract_response(Token, ClientContext, maps:put(nonce, any, Opts)),
                 case TokenRecord of
                     #oidcc_token{id = #oidcc_token_id{claims = #{<<"sub">> := ExpectedSub}}} ->
@@ -653,7 +701,7 @@ jwt_profile(Subject, ClientContext, Jwk, Opts) ->
             maybe
                 {ok, Token} ?=
                     retrieve_a_token(QueryString1, ClientContext, Opts, TelemetryOpts, false),
-                {ok, TokenRecord} ?=
+                {ok, TokenRecord, _Info} ?=
                     extract_response(Token, ClientContext, maps:put(nonce, any, Opts)),
                 case TokenRecord of
                     #oidcc_token{id = none} ->
@@ -715,14 +763,16 @@ client_credentials(ClientContext, Opts) ->
             maybe
                 {ok, Token} ?=
                     retrieve_a_token(QueryString1, ClientContext, Opts, TelemetryOpts, true),
-                extract_response(Token, ClientContext, maps:put(nonce, any, Opts))
+                {ok, TokenRecord, _Info} ?=
+                    extract_response(Token, ClientContext, maps:put(nonce, any, Opts)),
+                {ok, TokenRecord}
             end;
         false ->
             {error, {grant_type_not_supported, client_credentials}}
     end.
 
 -spec extract_response(TokenResponseBody, ClientContext, Opts) ->
-    {ok, t()} | {error, error()}
+    {ok, t(), refresh_info()} | {error, error()}
 when
     TokenResponseBody :: map(),
     ClientContext :: oidcc_client_context:t(),
@@ -733,7 +783,8 @@ extract_response(TokenResponseBody, ClientContext, Opts) ->
         {ok, AccessExpire} ?= extract_expiry(TokenResponseBody),
         {ok, AccessTokenRecord} ?= extract_access_token(TokenResponseBody, AccessExpire),
         {ok, RefreshTokenRecord} ?= extract_refresh_token(TokenResponseBody),
-        {ok, {IdTokenRecord, NoneUsed}} ?= extract_id_token(TokenResponseBody, ClientContext, Opts),
+        {ok, {IdTokenRecord, NoneUsed}, Info} ?=
+            extract_id_token(TokenResponseBody, ClientContext, Opts),
         TokenRecord = #oidcc_token{
             id = IdTokenRecord,
             access = AccessTokenRecord,
@@ -747,7 +798,7 @@ extract_response(TokenResponseBody, ClientContext, Opts) ->
             true ->
                 {error, {none_alg_used, TokenRecord}};
             false ->
-                {ok, TokenRecord}
+                {ok, TokenRecord, Info}
         end
     end.
 
@@ -812,7 +863,7 @@ extract_refresh_token(TokenMap) ->
     end.
 
 -spec extract_id_token(TokenMap, ClientContext, Opts) ->
-    {ok, {TokenRecord, NoneUsed}} | {error, error()}
+    {ok, {TokenRecord, NoneUsed}, refresh_info()} | {error, error()}
 when
     TokenMap :: map(),
     ClientContext :: oidcc_client_context:t(),
@@ -822,13 +873,13 @@ when
 extract_id_token(TokenMap, ClientContext, Opts) ->
     case maps:get(<<"id_token">>, TokenMap, none) of
         none ->
-            {ok, {none, false}};
+            {ok, {none, false}, undefined};
         Token when is_binary(Token) ->
-            case validate_id_token(Token, ClientContext, Opts) of
-                {ok, OkClaims} ->
-                    {ok, {#oidcc_token_id{token = Token, claims = OkClaims}, false}};
+            case validate_id_token_with_refresh(Token, ClientContext, Opts) of
+                {ok, OkClaims, Info} ->
+                    {ok, {#oidcc_token_id{token = Token, claims = OkClaims}, false}, Info};
                 {error, {none_alg_used, NoneClaims}} ->
-                    {ok, {#oidcc_token_id{token = Token, claims = NoneClaims}, true}};
+                    {ok, {#oidcc_token_id{token = Token, claims = NoneClaims}, true}, undefined};
                 {error, Reason} ->
                     {error, Reason}
             end;
@@ -907,6 +958,19 @@ validate_id_token(IdToken, ClientContext, Nonce) when is_binary(Nonce) ->
 validate_id_token(IdToken, ClientContext, any) ->
     validate_id_token(IdToken, ClientContext, #{nonce => any});
 validate_id_token(IdToken, ClientContext, Opts) when is_map(Opts) ->
+    case validate_id_token_with_refresh(IdToken, ClientContext, Opts) of
+        {ok, Claims, _Info} -> {ok, Claims};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-spec validate_id_token_with_refresh(IdToken, ClientContext, Opts) ->
+    {ok, Claims, refresh_info()} | {error, error()}
+when
+    IdToken :: binary(),
+    ClientContext :: oidcc_client_context:t(),
+    Opts :: retrieve_opts(),
+    Claims :: oidcc_jwt_util:claims().
+validate_id_token_with_refresh(IdToken, ClientContext, Opts) ->
     #oidcc_client_context{
         provider_configuration = Configuration,
         client_id = ClientId
@@ -941,7 +1005,7 @@ validate_id_token(IdToken, ClientContext, Opts) when is_map(Opts) ->
             List when is_list(List) -> List
         end,
 
-    validate_jwt(IdToken, ClientContext, ValidateOpts, fun(Claims) ->
+    validate_jwt_with_refresh(IdToken, ClientContext, ValidateOpts, fun(Claims) ->
         maybe
             ok ?= oidcc_jwt_util:verify_claims(Claims, ExpClaims),
             ok ?= verify_missing_required_claims(Claims),
@@ -1022,6 +1086,20 @@ when
     Claims :: oidcc_jwt_util:claims(),
     AdditionalClaimValidation :: fun((Claims) -> ok | {error, error()}).
 validate_jwt(Token, ClientContext, Opts, AdditionalClaimValidation) ->
+    case validate_jwt_with_refresh(Token, ClientContext, Opts, AdditionalClaimValidation) of
+        {ok, Claims, _Info} -> {ok, Claims};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-spec validate_jwt_with_refresh(Token, ClientContext, Opts, AdditionalClaimValidation) ->
+    {ok, Claims, refresh_info()} | {error, error()}
+when
+    Token :: binary(),
+    ClientContext :: oidcc_client_context:t(),
+    Opts :: validate_jwt_opts(),
+    Claims :: oidcc_jwt_util:claims(),
+    AdditionalClaimValidation :: fun((Claims) -> ok | {error, error()}).
+validate_jwt_with_refresh(Token, ClientContext, Opts, AdditionalClaimValidation) ->
     RefreshJwksFun = maps:get(refresh_jwks, Opts, undefined),
     unknown_kid_retry(
         fun(RefreshedClientContext) ->
@@ -1354,7 +1432,7 @@ rescue_none_validated_jwt(Other) ->
     Other.
 
 -spec unknown_kid_retry(Function, ClientContext, RefreshJwksFun) ->
-    {ok, Result} | {error, Error}
+    {ok, Result, refresh_info()} | {error, Error}
 when
     Function :: fun((ClientContext) -> {ok, Result} | {error, Error}),
     ClientContext :: oidcc_client_context:t(),
@@ -1364,15 +1442,32 @@ when
 unknown_kid_retry(Function, ClientContext, RefreshJwksFun) ->
     maybe
         {ok, Result} ?= Function(ClientContext),
-        {ok, Result}
+        {ok, Result, undefined}
     else
         {error, {no_matching_key_with_kid, Kid}} when RefreshJwksFun =/= undefined ->
             #oidcc_client_context{jwks = OldJwks} = ClientContext,
             maybe
-                {ok, RefreshedJwks} ?= RefreshJwksFun(OldJwks, Kid),
+                {ok, RefreshedJwks, Info} ?= refresh_jwks(RefreshJwksFun, OldJwks, Kid),
                 RefreshedClientContext = ClientContext#oidcc_client_context{jwks = RefreshedJwks},
-                Function(RefreshedClientContext)
+                {ok, Retried} ?= Function(RefreshedClientContext),
+                {ok, Retried, Info}
             end;
         {error, Reason} ->
             {error, Reason}
+    end.
+
+%% The three element return is what lets a caller learn what the refresh
+%% actually fetched. A function that only hands back a key forces anything else,
+%% the document and its expiry for instance, out through a side channel.
+-spec refresh_jwks(RefreshJwksFun, Jwks, Kid) ->
+    {ok, jose_jwk:key(), refresh_info()} | {error, term()}
+when
+    RefreshJwksFun :: oidcc_jwt_util:refresh_jwks_for_unknown_kid_fun(),
+    Jwks :: jose_jwk:key(),
+    Kid :: binary().
+refresh_jwks(RefreshJwksFun, Jwks, Kid) ->
+    case RefreshJwksFun(Jwks, Kid) of
+        {ok, RefreshedJwks} -> {ok, RefreshedJwks, undefined};
+        {ok, RefreshedJwks, Info} -> {ok, RefreshedJwks, Info};
+        {error, Reason} -> {error, Reason}
     end.

--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -2389,3 +2389,92 @@ client_context_fapi2_fixture() ->
     oidcc_client_context:from_manual(Configuration, Jwk, ClientId, ClientSecret, #{
         client_jwks => ClientJwk
     }).
+
+%% A refresh function that fetched a key set has no way to hand the document or
+%% its expiry back to its own caller, because oidcc calls it and consumes the
+%% result. The three element return reports it through retrieve_with_refresh/3.
+retrieve_with_refresh_reports_refresh_info_test() ->
+    PrivDir = code:priv_dir(oidcc),
+
+    OldJwk0 = jose_jwk:generate_key(16),
+    OldJwk = OldJwk0#jose_jwk{fields = #{<<"kid">> => <<"old">>}},
+    NewJwk0 = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
+    NewJwk = NewJwk0#jose_jwk{fields = #{<<"kid">> => <<"new">>}},
+
+    {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+    {ok, #oidcc_provider_configuration{issuer = Issuer} = Configuration} = oidcc_provider_configuration:decode_configuration(
+        json:decode(ConfigurationBinary)
+    ),
+
+    ClientId = <<"client_id">>,
+    ClientContext = oidcc_client_context:from_manual(
+        Configuration, OldJwk, ClientId, <<"client_secret">>
+    ),
+
+    Claims = #{
+        <<"iss">> => Issuer,
+        <<"sub">> => <<"sub">>,
+        <<"aud">> => ClientId,
+        <<"iat">> => erlang:system_time(second),
+        <<"exp">> => erlang:system_time(second) + 10
+    },
+    {_Jws, IdToken} =
+        jose_jws:compact(
+            jose_jwt:sign(
+                NewJwk, #{<<"alg">> => <<"RS256">>, <<"kid">> => <<"new">>}, jose_jwt:from(Claims)
+            )
+        ),
+
+    HttpFun =
+        fun(post, _Request, _HttpOpts, _Opts, _Config) ->
+            {ok, {
+                {"HTTP/1.1", 200, "OK"},
+                [{"content-type", "application/json"}],
+                iolist_to_binary(
+                    json:encode(#{
+                        <<"access_token">> => <<"access">>,
+                        <<"token_type">> => <<"Bearer">>,
+                        <<"id_token">> => IdToken,
+                        <<"scope">> => <<"openid">>
+                    })
+                )
+            }}
+        end,
+    Opts = #{
+        redirect_uri => <<"https://my.server/return">>,
+        request_opts => #{http_adapter => {oidcc_http_adapter_test, #{request => HttpFun}}}
+    },
+
+    %% Reporting nothing keeps the two element return working.
+    Quiet = fun(_Jwks, <<"new">>) -> {ok, NewJwk} end,
+    ?assertMatch(
+        {ok, #oidcc_token{}, undefined},
+        oidcc_token:retrieve_with_refresh(<<"code">>, ClientContext, Opts#{refresh_jwks => Quiet})
+    ),
+
+    %% Reporting the document and its expiry hands them to the caller.
+    Reporting =
+        fun(_Jwks, <<"new">>) -> {ok, NewJwk, {#{<<"keys">> => []}, 300_000}} end,
+    ?assertMatch(
+        {ok, #oidcc_token{}, {#{<<"keys">> := []}, 300_000}},
+        oidcc_token:retrieve_with_refresh(
+            <<"code">>, ClientContext, Opts#{refresh_jwks => Reporting}
+        )
+    ),
+
+    %% No refresh needed, nothing reported.
+    DirectContext = oidcc_client_context:from_manual(
+        Configuration, NewJwk, ClientId, <<"client_secret">>
+    ),
+    ?assertMatch(
+        {ok, #oidcc_token{}, undefined},
+        oidcc_token:retrieve_with_refresh(<<"code">>, DirectContext, Opts)
+    ),
+
+    %% retrieve/3 is unchanged.
+    ?assertMatch(
+        {ok, #oidcc_token{}},
+        oidcc_token:retrieve(<<"code">>, ClientContext, Opts#{refresh_jwks => Reporting})
+    ),
+
+    ok.


### PR DESCRIPTION
`refresh_jwks` is called by `oidcc` and its result is consumed by `oidcc`, so a callback
that fetches a key set has no way to report anything to whoever started the token
exchange. It returns `{ok, Jwks}` and the function that supplied it never hears from it
again.

That matters to any RP that stores its own JWKS rather than holding it in an
`oidcc_provider_configuration_worker`. When a token arrives with an unknown `kid` and the
refresh succeeds, the RP wants the new document and its expiry so it can persist them,
and there is no return path. hex.pm keeps provider metadata per organization in Postgres
shared across web nodes, so this is its normal case rather than an edge.

Neither workaround holds up. Writing the document into the process dictionary inside the
callback and reading it back afterwards works today, but only because the callback happens
to run in the calling process, which nothing in the API promises. Dropping `refresh_jwks`
and retrying from outside on `{error, {no_matching_key_with_kid, _}}` doesn't work at all:
`unknown_kid_retry/3` wraps validation only, so an outside retry re-sends the token
request, and RFC 6749 §4.1.2 makes the authorization code single use.

So this adds a return path rather than a side channel.
`oidcc_jwt_util:refresh_jwks_for_unknown_kid_fun()` gains `{ok, Jwks, Info}` alongside the
existing `{ok, Jwks}`, and `oidcc_token:retrieve_with_refresh/3` hands `Info` back.
`Info` is `term() | undefined` and `oidcc` never inspects it, it only carries it from the
callback to the caller.

Everything existing keeps its shape. A callback returning `{ok, Jwks}` behaves as before
and yields `undefined`. `retrieve/3` delegates to `retrieve_with_refresh/3` and drops the
third element, so its return is unchanged. `refresh/3`, `jwt_profile/4` and
`client_credentials/2` drop it too, since none of them exchange an authorization code and
the value has nowhere useful to go.

`Info` is non-`undefined` only when the callback ran and validation then succeeded against
the refreshed key set. `unknown_kid_retry/3` invokes the callback at most once and returns
`{error, _}` if the retry still fails, and on this path only the ID token goes through it,
so there is at most one refresh per exchange.
