### PR TITLE
Derive the at_hash digest from the ID token signing algorithm

### DIFF
--- a/src/oidcc_jwt_util.erl
+++ b/src/oidcc_jwt_util.erl
@@ -23,6 +23,7 @@
 -export([sign/3]).
 -export([sign/4]).
 -export([sign_dpop/3]).
+-export([signing_alg_to_digest/2]).
 -export([thumbprint/1]).
 -export([verify_claims/2]).
 -export([verify_not_none_alg/1]).
@@ -52,7 +53,8 @@ and consumes the result.
 
 -doc #{since => <<"3.0.0">>}.
 -type error() ::
-    no_matching_key
+    {unsupported_signing_alg, Alg :: atom()}
+    | no_matching_key
     | invalid_jwt_token
     | {no_matching_key_with_kid, Kid :: binary()}
     | none_alg_used
@@ -73,14 +75,15 @@ and consumes the result.
 %% in jose. see: https://github.com/potatosalad/erlang-jose/issues/28
 -doc false.
 -spec verify_signature(Token, AllowAlgorithms, Jwks) ->
-    {ok, {Jwt, Jws}}
+    {ok, {Jwt, Jws, Jwk}}
     | {error, error()}
 when
     Token :: binary(),
     AllowAlgorithms :: [binary()],
     Jwks :: jose_jwk:key(),
     Jwt :: #jose_jwt{},
-    Jws :: #jose_jws{}.
+    Jws :: #jose_jws{},
+    Jwk :: jose_jwk:key().
 verify_signature(Token, AllowAlgorithms, #jose_jwk{keys = {jose_jwk_set, Keys}}) ->
     lists:foldl(
         fun
@@ -114,7 +117,7 @@ verify_signature(Token, AllowAlgorithms, #jose_jwk{} = Jwks) ->
             #jose_jwk{} ->
                 case jose_jwt:verify_strict(Jwks, AllowAlgorithms, Token) of
                     {true, Jwt, Jws} ->
-                        {ok, {Jwt, Jws}};
+                        {ok, {Jwt, Jws, Jwks}};
                     {false, Jwt, #jose_jws{alg = {jose_jws_alg_none, none}} = Jws} ->
                         {error, {none_alg_used, Jwt, Jws}};
                     {false, _Jwt, _Jws} ->
@@ -291,7 +294,7 @@ sign(Jwt, Jwk, [Algorithm | RestAlgorithms], JwsFields0) ->
     EncryptionAlgs :: [binary()] | undefined,
     EncryptionEncs :: [binary()] | undefined
 ) ->
-    {ok, {#jose_jwt{}, #jose_jwe{} | #jose_jws{}}} | {error, error()}.
+    {ok, {#jose_jwt{}, #jose_jwe{} | #jose_jws{}, jose_jwk:key() | none}} | {error, error()}.
 decrypt_and_verify(Jwt, Jwks, SigningAlgs, EncryptionAlgs, EncryptionEncs) ->
     %% we call jwe_peek_protected/1 before `decrypt/4' so that we can
     %% handle unencrypted tokens in the case where SupportedAlgorithms /
@@ -402,9 +405,9 @@ verify_decrypted_token(Jwt, SigningAlgs, Jwe, Jwks) ->
             %% encrypted + signed (nested) JWT
             {ok, Result};
         {error, invalid_jwt_token} ->
-            %% encrypted JWT
+            %% encrypted JWT, not signed: there is no signing key
             try
-                {ok, {jose_jwt:from_binary(Jwt), Jwe}}
+                {ok, {jose_jwt:from_binary(Jwt), Jwe, none}}
             catch
                 _ -> {error, invalid_jwt_token}
             end;
@@ -517,6 +520,63 @@ verify_not_none_alg(#jose_jws{fields = #{<<"alg">> := <<"none">>}}) ->
     {error, none_alg_used};
 verify_not_none_alg(#jose_jws{}) ->
     ok.
+
+%% Digest used by the given JWS signing algorithm.
+%%
+%% Used to derive the hash algorithm for the `at_hash' / `c_hash' claims, which
+%% are defined in terms of "the hash algorithm used in the `alg' Header
+%% Parameter of the ID Token's JOSE Header".
+%%
+%% Most algorithms name their digest in the `alg' itself. `EdDSA' does not, so
+%% it is derived from the curve of the key the token was signed with.
+%%
+%% See https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
+-doc false.
+-spec signing_alg_to_digest(Alg, Jwk) ->
+    {ok, crypto:sha2()} | {error, {unsupported_signing_alg, atom()}}
+when
+    Alg :: atom(),
+    Jwk :: jose_jwk:key() | none.
+signing_alg_to_digest('RS256', _Jwk) ->
+    {ok, sha256};
+signing_alg_to_digest('RS384', _Jwk) ->
+    {ok, sha384};
+signing_alg_to_digest('RS512', _Jwk) ->
+    {ok, sha512};
+signing_alg_to_digest('PS256', _Jwk) ->
+    {ok, sha256};
+signing_alg_to_digest('PS384', _Jwk) ->
+    {ok, sha384};
+signing_alg_to_digest('PS512', _Jwk) ->
+    {ok, sha512};
+%% `ES512' uses the P-521 curve, but still hashes with SHA-512.
+signing_alg_to_digest('ES256', _Jwk) ->
+    {ok, sha256};
+signing_alg_to_digest('ES384', _Jwk) ->
+    {ok, sha384};
+signing_alg_to_digest('ES512', _Jwk) ->
+    {ok, sha512};
+signing_alg_to_digest('HS256', _Jwk) ->
+    {ok, sha256};
+signing_alg_to_digest('HS384', _Jwk) ->
+    {ok, sha384};
+signing_alg_to_digest('HS512', _Jwk) ->
+    {ok, sha512};
+%% OpenID Connect Core does not define which digest to use for `EdDSA': the
+%% `alg' header only says "EdDSA", so it can only be derived from the key's
+%% curve. There is an unpublished OpenID WG proposal to standardise this; in
+%% the meantime this follows the de-facto behaviour of using SHA-512 for
+%% Ed25519.
+%%
+%% Ed448 uses SHAKE256, which is not a `crypto:sha2()', and is therefore
+%% rejected rather than silently hashed with the wrong digest.
+signing_alg_to_digest('EdDSA', #jose_jwk{kty = {jose_jwk_kty_okp_ed25519, _Key}}) ->
+    {ok, sha512};
+signing_alg_to_digest('EdDSA', #jose_jwk{kty = {jose_jwk_kty_okp_ed25519ph, _Key}}) ->
+    {ok, sha512};
+%% `ES256K' is not an OpenID Connect signing algorithm.
+signing_alg_to_digest(Alg, _Jwk) ->
+    {error, {unsupported_signing_alg, Alg}}.
 
 -doc false.
 -spec peek_payload(binary()) -> {ok, #jose_jwt{}} | {error, invalid_jwt_token}.

--- a/src/oidcc_token.erl
+++ b/src/oidcc_token.erl
@@ -518,7 +518,7 @@ validate_jarm(Response, ClientContext, Opts) ->
     %% 5. validate signature (valid, not <<"none">> alg)
     %% 6. continue processing
     maybe
-        {ok, {#jose_jwt{fields = Claims}, Jws}} ?=
+        {ok, {#jose_jwt{fields = Claims}, Jws, _Jwk}} ?=
             oidcc_jwt_util:decrypt_and_verify(
                 Response, Jwks, SigningAlgSupported, EncryptionAlgSupported, EncryptionEncSupported
             ),
@@ -783,7 +783,7 @@ extract_response(TokenResponseBody, ClientContext, Opts) ->
         {ok, AccessExpire} ?= extract_expiry(TokenResponseBody),
         {ok, AccessTokenRecord} ?= extract_access_token(TokenResponseBody, AccessExpire),
         {ok, RefreshTokenRecord} ?= extract_refresh_token(TokenResponseBody),
-        {ok, {IdTokenRecord, NoneUsed}, Info} ?=
+        {ok, {IdTokenRecord, IdTokenJwk, NoneUsed}, Info} ?=
             extract_id_token(TokenResponseBody, ClientContext, Opts),
         TokenRecord = #oidcc_token{
             id = IdTokenRecord,
@@ -791,7 +791,7 @@ extract_response(TokenResponseBody, ClientContext, Opts) ->
             refresh = RefreshTokenRecord,
             scope = Scopes
         },
-        ok ?= verify_access_token_map_hash(TokenRecord),
+        ok ?= verify_access_token_map_hash(TokenRecord, IdTokenJwk),
         %% If none alg was used, continue with checks to allow the user to decide
         %% if he wants to use the result
         case NoneUsed of
@@ -863,23 +863,25 @@ extract_refresh_token(TokenMap) ->
     end.
 
 -spec extract_id_token(TokenMap, ClientContext, Opts) ->
-    {ok, {TokenRecord, NoneUsed}, refresh_info()} | {error, error()}
+    {ok, {TokenRecord, Jwk, NoneUsed}, refresh_info()} | {error, error()}
 when
     TokenMap :: map(),
     ClientContext :: oidcc_client_context:t(),
     Opts :: retrieve_opts(),
-    TokenRecord :: id(),
+    TokenRecord :: id() | none,
+    Jwk :: jose_jwk:key() | none,
     NoneUsed :: boolean().
 extract_id_token(TokenMap, ClientContext, Opts) ->
     case maps:get(<<"id_token">>, TokenMap, none) of
         none ->
-            {ok, {none, false}, undefined};
+            {ok, {none, none, false}, undefined};
         Token when is_binary(Token) ->
             case validate_id_token_with_refresh(Token, ClientContext, Opts) of
-                {ok, OkClaims, Info} ->
-                    {ok, {#oidcc_token_id{token = Token, claims = OkClaims}, false}, Info};
+                {ok, {OkClaims, Jwk}, Info} ->
+                    {ok, {#oidcc_token_id{token = Token, claims = OkClaims}, Jwk, false}, Info};
                 {error, {none_alg_used, NoneClaims}} ->
-                    {ok, {#oidcc_token_id{token = Token, claims = NoneClaims}, true}, undefined};
+                    {ok, {#oidcc_token_id{token = Token, claims = NoneClaims}, none, true},
+                        undefined};
                 {error, Reason} ->
                     {error, Reason}
             end;
@@ -887,25 +889,62 @@ extract_id_token(TokenMap, ClientContext, Opts) ->
             {error, {invalid_property, {id_token, Other}}}
     end.
 
--spec verify_access_token_map_hash(TokenRecord :: t()) ->
-    ok | {error, error()}.
-verify_access_token_map_hash(#oidcc_token{
-    id =
-        #oidcc_token_id{
-            claims =
-                #{<<"at_hash">> := ExpectedHash}
-        },
-    access = #oidcc_token_access{token = AccessToken}
-}) ->
-    <<BinHash:16/binary, _Rest/binary>> = crypto:hash(sha256, AccessToken),
-    case base64:encode(BinHash, #{mode => urlsafe, padding => false}) of
-        ExpectedHash ->
-            ok;
-        _Other ->
-            {error, bad_access_token_hash}
+-spec verify_access_token_map_hash(TokenRecord, Jwk) ->
+    ok | {error, error()}
+when
+    TokenRecord :: t(),
+    Jwk :: jose_jwk:key() | none.
+verify_access_token_map_hash(
+    #oidcc_token{
+        id =
+            #oidcc_token_id{
+                token = IdToken,
+                claims =
+                    #{<<"at_hash">> := ExpectedHash}
+            },
+        access = #oidcc_token_access{token = AccessToken}
+    },
+    Jwk
+) ->
+    maybe
+        {ok, Digest} ?= id_token_hash_digest(IdToken, Jwk),
+        %% The hash is truncated to its left-most half, the length of which
+        %% depends on the digest used. For SHA-256 this is the left-most 128
+        %% bits.
+        %% See https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
+        Hash = crypto:hash(Digest, AccessToken),
+        BinHash = binary:part(Hash, 0, byte_size(Hash) div 2),
+        case base64:encode(BinHash, #{mode => urlsafe, padding => false}) of
+            ExpectedHash ->
+                ok;
+            _Other ->
+                {error, bad_access_token_hash}
+        end
     end;
-verify_access_token_map_hash(#oidcc_token{}) ->
+verify_access_token_map_hash(#oidcc_token{}, _Jwk) ->
     ok.
+
+%% Digest to use for the `at_hash' claim of the given ID token.
+%%
+%% The digest is derived from the `alg' header of the ID token, which has
+%% already been checked against the allowed signing algorithms when the
+%% signature was verified.
+%%
+%% `EdDSA' does not name a digest, so it is derived from the curve of the key
+%% the token was signed with.
+-spec id_token_hash_digest(IdToken, Jwk) ->
+    {ok, crypto:sha2()} | {error, oidcc_jwt_util:error()}
+when
+    IdToken :: binary(),
+    Jwk :: jose_jwk:key() | none.
+id_token_hash_digest(_IdToken, none) ->
+    %% Encrypted without a nested signature, or the `none' algorithm was used:
+    %% there is no signing algorithm to derive a digest from, so an `at_hash'
+    %% cannot be verified.
+    {error, {unsupported_signing_alg, undefined}};
+id_token_hash_digest(IdToken, Jwk) ->
+    #jose_jws{alg = {_Module, Alg}} = jose_jwt:peek_protected(IdToken),
+    oidcc_jwt_util:signing_alg_to_digest(Alg, Jwk).
 
 -doc """
 Validate ID Token
@@ -959,12 +998,12 @@ validate_id_token(IdToken, ClientContext, any) ->
     validate_id_token(IdToken, ClientContext, #{nonce => any});
 validate_id_token(IdToken, ClientContext, Opts) when is_map(Opts) ->
     case validate_id_token_with_refresh(IdToken, ClientContext, Opts) of
-        {ok, Claims, _Info} -> {ok, Claims};
+        {ok, {Claims, _Jwk}, _Info} -> {ok, Claims};
         {error, Reason} -> {error, Reason}
     end.
 
 -spec validate_id_token_with_refresh(IdToken, ClientContext, Opts) ->
-    {ok, Claims, refresh_info()} | {error, error()}
+    {ok, {Claims, jose_jwk:key() | none}, refresh_info()} | {error, error()}
 when
     IdToken :: binary(),
     ClientContext :: oidcc_client_context:t(),
@@ -1087,12 +1126,12 @@ when
     AdditionalClaimValidation :: fun((Claims) -> ok | {error, error()}).
 validate_jwt(Token, ClientContext, Opts, AdditionalClaimValidation) ->
     case validate_jwt_with_refresh(Token, ClientContext, Opts, AdditionalClaimValidation) of
-        {ok, Claims, _Info} -> {ok, Claims};
+        {ok, {Claims, _Jwk}, _Info} -> {ok, Claims};
         {error, Reason} -> {error, Reason}
     end.
 
 -spec validate_jwt_with_refresh(Token, ClientContext, Opts, AdditionalClaimValidation) ->
-    {ok, Claims, refresh_info()} | {error, error()}
+    {ok, {Claims, jose_jwk:key() | none}, refresh_info()} | {error, error()}
 when
     Token :: binary(),
     ClientContext :: oidcc_client_context:t(),
@@ -1112,7 +1151,7 @@ validate_jwt_with_refresh(Token, ClientContext, Opts, AdditionalClaimValidation)
     ).
 
 -spec int_validate_jwt(Token, ClientContext, Opts, AdditionalClaimValidation) ->
-    {ok, Claims} | {error, error()}
+    {ok, {Claims, jose_jwk:key() | none}} | {error, error()}
 when
     Token :: binary(),
     ClientContext :: oidcc_client_context:t(),
@@ -1155,7 +1194,7 @@ int_validate_jwt(Token, ClientContext, Opts, AdditionalClaimValidation) ->
     TrustedAudiences = maps:get(trusted_audiences, Opts, any),
 
     maybe
-        {ok, {#jose_jwt{fields = Claims}, Jws}} ?=
+        {ok, {#jose_jwt{fields = Claims}, Jws, Jwk}} ?=
             rescue_none_validated_jwt(
                 oidcc_jwt_util:decrypt_and_verify(
                     Token, Jwks, SigningAlgs, EncryptionAlgs, EncryptionEncs
@@ -1178,9 +1217,9 @@ int_validate_jwt(Token, ClientContext, Opts, AdditionalClaimValidation) ->
             #jose_jws{alg = {jose_jws_alg_none, none}} ->
                 {error, {none_alg_used, Claims}};
             #jose_jws{} ->
-                {ok, Claims};
+                {ok, {Claims, Jwk}};
             #jose_jwe{} ->
-                {ok, Claims}
+                {ok, {Claims, none}}
         end
     end.
 
@@ -1422,12 +1461,16 @@ add_pkce_verifier(BodyQs, _Opts, _ClientContext) ->
     {ok, BodyQs}.
 
 -spec rescue_none_validated_jwt(Result) -> Response when
-    Response :: {ok, {#jose_jwt{}, #jose_jwe{} | #jose_jws{}}} | {error, oidcc_jwt_util:error()},
-    Result :: {ok, {#jose_jwt{}, #jose_jwe{} | #jose_jws{}}} | {error, oidcc_jwt_util:error()}.
+    Response ::
+        {ok, {#jose_jwt{}, #jose_jwe{} | #jose_jws{}, jose_jwk:key() | none}}
+        | {error, oidcc_jwt_util:error()},
+    Result ::
+        {ok, {#jose_jwt{}, #jose_jwe{} | #jose_jws{}, jose_jwk:key() | none}}
+        | {error, oidcc_jwt_util:error()}.
 rescue_none_validated_jwt({ok, Valid}) ->
     {ok, Valid};
 rescue_none_validated_jwt({error, {none_alg_used, Jwt0, Jws0}}) ->
-    {ok, {Jwt0, Jws0}};
+    {ok, {Jwt0, Jws0, none}};
 rescue_none_validated_jwt(Other) ->
     Other.
 

--- a/src/oidcc_userinfo.erl
+++ b/src/oidcc_userinfo.erl
@@ -278,7 +278,7 @@ validate_userinfo_token(UserinfoToken, ClientContext, Opts) ->
                 _ ->
                     Jwks2
             end,
-        {ok, {#jose_jwt{fields = Claims}, JwsOrJwe}} ?=
+        {ok, {#jose_jwt{fields = Claims}, JwsOrJwe, _Jwk}} ?=
             oidcc_jwt_util:decrypt_and_verify(
                 UserinfoToken,
                 Jwks,

--- a/test/oidcc_token_test.erl
+++ b/test/oidcc_token_test.erl
@@ -1740,8 +1740,10 @@ authorization_headers_test() ->
         oidcc_jwt_util:verify_signature(DpopProofWithNonce, SigningAlg, ClientJwk)
     ),
 
-    {ok, {DpopJwt, DpopJws}} = oidcc_jwt_util:verify_signature(DpopProof, SigningAlg, ClientJwk),
-    {ok, {DpopJwtWithNonce, DpopJwsWithNonce}} = oidcc_jwt_util:verify_signature(
+    {ok, {DpopJwt, DpopJws, _DpopJwk}} = oidcc_jwt_util:verify_signature(
+        DpopProof, SigningAlg, ClientJwk
+    ),
+    {ok, {DpopJwtWithNonce, DpopJwsWithNonce, _DpopJwkWithNonce}} = oidcc_jwt_util:verify_signature(
         DpopProofWithNonce, SigningAlg, ClientJwk
     ),
 
@@ -2365,6 +2367,303 @@ validate_jwt_with_regex_issuer_test() ->
         {error, {missing_claim, {<<"iss">>, {regex, RegexPattern}}, _}},
         oidcc_token:validate_jwt(JwtFun(NoMatch2), ClientContext, Opts)
     ),
+
+    ok.
+
+at_hash_signing_alg_test_() ->
+    %% https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
+    %%
+    %% `at_hash' is the base64url encoding of the *left-most half* of the hash
+    %% of the access token, where the hash algorithm is the one used in the
+    %% `alg' header of the ID Token's JOSE header.
+    %%
+    %% Both the digest *and* the truncation length therefore depend on `alg':
+    %%
+    %%   *256 -> sha256, 32 byte digest, left-most 16 bytes
+    %%   *384 -> sha384, 48 byte digest, left-most 24 bytes
+    %%   *512 -> sha512, 64 byte digest, left-most 32 bytes
+    %%
+    %% The "left-most 128 bits" in the spec is an example given for RS256, not
+    %% a fixed length.
+    %%
+    %% Note that ES512 uses P-521 (not P-512) but still hashes with SHA-512.
+    %%
+    %% EdDSA is deliberately excluded here, see `at_hash_eddsa_test_/0'.
+    {timeout, 60, [
+        {binary_to_list(Alg), fun() -> at_hash_signing_alg(Alg, Digest, KeyType) end}
+     || {Alg, Digest, KeyType} <- [
+            {<<"RS256">>, sha256, rsa},
+            {<<"RS384">>, sha384, rsa},
+            {<<"RS512">>, sha512, rsa},
+            {<<"PS256">>, sha256, rsa},
+            {<<"PS384">>, sha384, rsa},
+            {<<"PS512">>, sha512, rsa},
+            {<<"ES256">>, sha256, {ec, <<"P-256">>}},
+            {<<"ES384">>, sha384, {ec, <<"P-384">>}},
+            {<<"ES512">>, sha512, {ec, <<"P-521">>}},
+            {<<"HS256">>, sha256, oct},
+            {<<"HS384">>, sha384, oct},
+            {<<"HS512">>, sha512, oct}
+        ]
+    ]}.
+
+at_hash_eddsa_test_() ->
+    %% OpenID Connect Core does not define which hash to use for EdDSA: the
+    %% `alg' header only says "EdDSA", so the digest can only be derived from
+    %% the key's curve (Ed25519 -> SHA-512, Ed448 -> SHAKE256).
+    %%
+    %% There is an unpublished OpenID WG proposal to standardise this. In the
+    %% meantime the de-facto behaviour (e.g. panva/oidc-token-hash) is to use
+    %% SHA-512 for Ed25519, which is what we assert here.
+    {timeout, 60, [
+        {"EdDSA (Ed25519)", fun() ->
+            at_hash_signing_alg(<<"EdDSA">>, sha512, ed25519)
+        end}
+    ]}.
+
+at_hash_signing_alg(Alg, Digest, KeyType) ->
+    PrivDir = code:priv_dir(oidcc),
+
+    {ok, _} = application:ensure_all_started(oidcc),
+
+    {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+    {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
+        json:decode(ConfigurationBinary)
+    ),
+
+    #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
+        Configuration = Configuration0#oidcc_provider_configuration{
+            token_endpoint_auth_methods_supported = [<<"client_secret_post">>],
+            id_token_signing_alg_values_supported = [Alg]
+        },
+
+    ClientId = <<"client_id">>,
+    %% HS* derives the signing key from the client secret, so it must be long
+    %% enough for the largest digest we sign with (HS512 -> 64 bytes).
+    ClientSecret = binary:copy(<<"client_secret">>, 8),
+    LocalEndpoint = <<"https://my.server/auth">>,
+    AuthCode = <<"1234567890">>,
+    AccessToken = <<"access_token">>,
+
+    %% Derived from the spec rather than from the implementation, so that this
+    %% stays an independent check of the implementation.
+    FullHash = crypto:hash(Digest, AccessToken),
+    LeftMostHalf = binary:part(FullHash, 0, byte_size(FullHash) div 2),
+    AtHash = base64:encode(LeftMostHalf, #{mode => urlsafe, padding => false}),
+
+    Claims =
+        #{
+            <<"iss">> => Issuer,
+            <<"sub">> => <<"sub">>,
+            <<"aud">> => ClientId,
+            <<"iat">> => erlang:system_time(second),
+            <<"exp">> => erlang:system_time(second) + 10,
+            <<"at_hash">> => AtHash
+        },
+
+    %% Key used to sign the ID token. For HS* the provider and the client share
+    %% the client secret as the signing key.
+    SigningJwk =
+        case KeyType of
+            rsa ->
+                jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem");
+            ed25519 ->
+                jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk-ed25519.pem");
+            {ec, Curve} ->
+                jose_jwk:generate_key({ec, Curve});
+            oct ->
+                jose_jwk:from_oct(ClientSecret)
+        end,
+
+    Jwt = jose_jwt:from(Claims),
+    Jws = #{<<"alg">> => Alg},
+    {_Jws, Token} = jose_jws:compact(jose_jwt:sign(SigningJwk, Jws, Jwt)),
+
+    TokenData =
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>
+            })
+        ),
+
+    ClientContext = oidcc_client_context:from_manual(
+        Configuration, SigningJwk, ClientId, ClientSecret
+    ),
+
+    ok = meck:new(httpc, [no_link]),
+    HttpFun =
+        fun(post, {ReqTokenEndpoint, _Header, _ContentType, _Body}, _HttpOpts, _Opts, _Profile) ->
+            TokenEndpoint = ReqTokenEndpoint,
+            {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], TokenData}}
+        end,
+    ok = meck:expect(httpc, request, HttpFun),
+
+    try
+        ?assertMatch(
+            {ok, #oidcc_token{
+                id = #oidcc_token_id{token = Token},
+                access = #oidcc_token_access{token = AccessToken}
+            }},
+            oidcc_token:retrieve(
+                AuthCode,
+                ClientContext,
+                #{redirect_uri => LocalEndpoint}
+            )
+        )
+    after
+        meck:unload(httpc)
+    end,
+
+    ok.
+
+at_hash_none_alg_test() ->
+    %% An unsigned token has no signing algorithm, and therefore no hash
+    %% algorithm to verify the `at_hash' claim with. The claim must not be
+    %% silently accepted.
+    PrivDir = code:priv_dir(oidcc),
+
+    jose:unsecured_signing(true),
+
+    {ok, _} = application:ensure_all_started(oidcc),
+
+    {ok, ConfigurationBinary} = file:read_file(PrivDir ++ "/test/fixtures/example-metadata.json"),
+    {ok, Configuration0} = oidcc_provider_configuration:decode_configuration(
+        json:decode(ConfigurationBinary)
+    ),
+
+    #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
+        Configuration = Configuration0#oidcc_provider_configuration{
+            token_endpoint_auth_methods_supported = [<<"client_secret_post">>]
+        },
+
+    ClientId = <<"client_id">>,
+    ClientSecret = <<"client_secret">>,
+    LocalEndpoint = <<"https://my.server/auth">>,
+    AuthCode = <<"1234567890">>,
+    AccessToken = <<"access_token">>,
+
+    Claims =
+        #{
+            <<"iss">> => Issuer,
+            <<"sub">> => <<"sub">>,
+            <<"aud">> => ClientId,
+            <<"iat">> => erlang:system_time(second),
+            <<"exp">> => erlang:system_time(second) + 10,
+            %% Correct SHA-256 hash of the access token, which must still not be
+            %% accepted, since the token is unsigned.
+            <<"at_hash">> => <<"hrOQHuo3oE6FR82RIiX1SA">>
+        },
+
+    Jwk = jose_jwk:from_pem_file(PrivDir ++ "/test/fixtures/jwk.pem"),
+    Jwt = jose_jwt:from(Claims),
+    {_Jws, Token} = jose_jws:compact(jose_jwt:sign(Jwk, #{<<"alg">> => <<"none">>}, Jwt)),
+
+    TokenData =
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>
+            })
+        ),
+
+    ClientContext = oidcc_client_context:from_manual(Configuration, Jwk, ClientId, ClientSecret),
+
+    ok = meck:new(httpc, [no_link]),
+    HttpFun =
+        fun(post, {ReqTokenEndpoint, _Header, _ContentType, _Body}, _HttpOpts, _Opts, _Profile) ->
+            TokenEndpoint = ReqTokenEndpoint,
+            {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], TokenData}}
+        end,
+    ok = meck:expect(httpc, request, HttpFun),
+
+    try
+        ?assertMatch(
+            {error, {unsupported_signing_alg, undefined}},
+            oidcc_token:retrieve(
+                AuthCode,
+                ClientContext,
+                #{redirect_uri => LocalEndpoint}
+            )
+        )
+    after
+        meck:unload(httpc),
+        jose:unsecured_signing(false)
+    end,
+
+    ok.
+
+at_hash_encrypted_not_signed_test() ->
+    %% A token that is encrypted but not signed has no signing algorithm, and
+    %% therefore no hash algorithm to verify the `at_hash' claim with. The claim
+    %% must not be silently accepted.
+    #oidcc_client_context{client_id = ClientId, jwks = Jwk, provider_configuration = Configuration0} =
+        ClientContext0 = client_context_fapi2_fixture(),
+
+    #oidcc_provider_configuration{token_endpoint = TokenEndpoint, issuer = Issuer} =
+        Configuration = Configuration0#oidcc_provider_configuration{
+            token_endpoint_auth_methods_supported = [<<"client_secret_post">>],
+            id_token_encryption_alg_values_supported = [<<"RSA-OAEP">>],
+            id_token_encryption_enc_values_supported = [<<"A256GCM">>]
+        },
+
+    ClientContext = ClientContext0#oidcc_client_context{provider_configuration = Configuration},
+
+    LocalEndpoint = <<"https://my.server/auth">>,
+    AuthCode = <<"1234567890">>,
+    AccessToken = <<"access_token">>,
+
+    Claims =
+        #{
+            <<"iss">> => Issuer,
+            <<"sub">> => <<"sub">>,
+            <<"aud">> => ClientId,
+            <<"iat">> => erlang:system_time(second),
+            <<"exp">> => erlang:system_time(second) + 10,
+            %% Correct SHA-256 hash of the access token, which must still not be
+            %% accepted, since the token is not signed.
+            <<"at_hash">> => <<"hrOQHuo3oE6FR82RIiX1SA">>
+        },
+
+    %% Encrypted directly, without a nested signature.
+    {_, IdTokenJwt} = jose_jwt:to_binary(Claims),
+    Jwe = #{<<"alg">> => <<"RSA-OAEP">>, <<"enc">> => <<"A256GCM">>},
+    {_Jwe, Token} = jose_jwe:compact(jose_jwk:block_encrypt(IdTokenJwt, Jwe, Jwk)),
+
+    TokenData =
+        iolist_to_binary(
+            json:encode(#{
+                <<"access_token">> => AccessToken,
+                <<"token_type">> => <<"Bearer">>,
+                <<"id_token">> => Token,
+                <<"scope">> => <<"profile openid">>
+            })
+        ),
+
+    ok = meck:new(httpc, [no_link]),
+    HttpFun =
+        fun(post, {ReqTokenEndpoint, _Header, _ContentType, _Body}, _HttpOpts, _Opts, _Profile) ->
+            TokenEndpoint = ReqTokenEndpoint,
+            {ok, {{"HTTP/1.1", 200, "OK"}, [{"content-type", "application/json"}], TokenData}}
+        end,
+    ok = meck:expect(httpc, request, HttpFun),
+
+    try
+        ?assertMatch(
+            {error, {unsupported_signing_alg, undefined}},
+            oidcc_token:retrieve(
+                AuthCode,
+                ClientContext,
+                #{redirect_uri => LocalEndpoint}
+            )
+        )
+    after
+        meck:unload(httpc)
+    end,
 
     ok.
 


### PR DESCRIPTION
`at_hash` is the base64url encoding of the left-most half of the hash of the access token, where the hash algorithm is the one used in the `alg` header of the ID token's JOSE header.

Both the digest and the truncation length were hardcoded to SHA-256 and 16 bytes, so validation failed for every algorithm other than `*256`. The "left-most 128 bits" in the specification is an example given for RS256, not a fixed length: RS384 truncates to 24 bytes and RS512 to 32.

The digest is now derived from the `alg` header, and the truncation length from the digest size. `EdDSA` does not name a digest, so it is resolved from the curve of the key the token was signed with, which is threaded through to the hash check without being stored on the token record.

An `at_hash` that cannot be verified is rejected rather than skipped: unsigned tokens and tokens that are encrypted without a nested signature have no signing algorithm to derive a digest from.

Fixes #481
